### PR TITLE
Fix substitution for hiding contexts/projects

### DIFF
--- a/tests/t1330-ls-highlighting.sh
+++ b/tests/t1330-ls-highlighting.sh
@@ -148,4 +148,22 @@ TODO: 4 marked as done.
 TODO: 5 of 5 tasks shown
 EOF
 
+# check highlighting with hidden contexts/projects
+#
+cat > todo.txt <<EOF
+(A) +project at the beginning, with priority
+(B) with priority, ending in a +project
+(C) @context at the beginning, with priority
+(Z) with priority, ending in a @context
+EOF
+test_todo_session 'highlighting with hidden contexts/projects' <<EOF
+>>> todo.sh -+ -@ list
+[1;33m1 (A) at the beginning, with priority[0m
+[0;32m2 (B) with priority, ending in a[0m
+[1;34m3 (C) at the beginning, with priority[0m
+[1;37m4 (Z) with priority, ending in a[0m
+--
+TODO: 4 of 4 tasks shown
+EOF
+
 test_done

--- a/todo.sh
+++ b/todo.sh
@@ -360,7 +360,7 @@ do
             unset HIDE_CONTEXTS_SUBSTITUTION
         else
             ## One or odd value -- hide context names
-            export HIDE_CONTEXTS_SUBSTITUTION='[[:space:]]@[^[:space:]]\{1,\}'
+            export HIDE_CONTEXTS_SUBSTITUTION='[[:space:]]@[[:graph:]]\{1,\}'
         fi
         ;;
     '+' )
@@ -376,7 +376,7 @@ do
             unset HIDE_PROJECTS_SUBSTITUTION
         else
             ## One or odd value -- hide project names
-            export HIDE_PROJECTS_SUBSTITUTION='[[:space:]][+][^[:space:]]\{1,\}'
+            export HIDE_PROJECTS_SUBSTITUTION='[[:space:]][+][[:graph:]]\{1,\}'
         fi
         ;;
     a )


### PR DESCRIPTION
When using the -+ or -@ option to hide project or context names in list output, the color reset sequence was being deleted if the project/context was at the end of the line.  This caused a task's color to continue on to the next lines.
