### PR TITLE
Make todo.sh more portable

### DIFF
--- a/todo.cfg
+++ b/todo.cfg
@@ -2,7 +2,7 @@
 
 # Your todo.txt directory
 #export TODO_DIR="/Users/gina/Documents/todo"
-export TODO_DIR=`dirname $0`
+export TODO_DIR=`dirname "$0"`
 
 # Your todo/done/report.txt locations
 export TODO_FILE="$TODO_DIR/todo.txt"

--- a/todo.sh
+++ b/todo.sh
@@ -498,7 +498,7 @@ export SENTENCE_DELIMITERS=',.:;'
 }
 
 [ -e "$TODOTXT_CFG_FILE" ] || {
-    CFG_FILE_ALT=`dirname $0`"/todo.cfg"
+    CFG_FILE_ALT=`dirname "$0"`"/todo.cfg"
 
     if [ -e "$CFG_FILE_ALT" ]
     then


### PR DESCRIPTION
These two changes make todo.sh more portable by allowing todo.cfg to be autodetected in the same directory as todo.sh, and by defaulting TODO_DIR to that same directory. This makes everything run very nicely in Dropbox (if everything's put in /todo it runs on all desktops and with Todo.txt Touch without any fuss). This also allows todo.sh to run successfully out-of-the-box without any configuration.
