### PR TITLE
Portable action d

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -24,3 +24,8 @@ h2. Quick Links
 * "Add-on Directory":http://wiki.github.com/ginatrapani/todo.txt-cli/todosh-add-on-directory
 * "Changelog":http://wiki.github.com/ginatrapani/todo.txt-cli/todosh-changelog
 * "Known Bugs":http://github.com/ginatrapani/todo.txt-cli/issues
+
+h2. Changes from the original
+
+* This adds a custom addon folder
+* This adds a capability for the addon folder to be relative to the path of todo.sh if the previously defined locations are not present

--- a/todo.sh
+++ b/todo.sh
@@ -546,14 +546,16 @@ then
     export TODO_ACTIONS_DIR
 fi
 
-[ -d "$TODO_ACTIONS_DIR" ] || {
-    TODO_ACTIONS_DIR_ALT="$HOME/.todo.actions.d"
-
-    if [ -d "$TODO_ACTIONS_DIR_ALT" ]
-    then
-        TODO_ACTIONS_DIR="$TODO_ACTIONS_DIR_ALT"
-    fi
-}
+if [ -d "$TODO_ACTIONS_DIR" ]
+then
+    true
+elif [ -d "$HOME/.todo.actions.d" ]
+then
+    TODO_ACTIONS_DIR="$HOME/.todo.actions.d"
+elif [ -d "$(dirname "$0")/actions.d" ]
+then
+    TODO_ACTIONS_DIR=$(dirname "$0")"/actions.d"
+fi
 
 # === SANITY CHECKS (thanks Karl!) ===
 [ -r "$TODOTXT_CFG_FILE" ] || die "Fatal Error: Cannot read configuration file $TODOTXT_CFG_FILE"


### PR DESCRIPTION
This one adds on to the portability by allowing action.d in the current folder of todo.sh to be used as the action.d folder (assuming the one used in the previous versions do not work).
