### PR TITLE
Simplified check for done task.

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -953,7 +953,7 @@ case $action in
         [ -z "$todo" ] && die "TODO: No task $item."
 
         # Check if this item has already been done
-        if [ `echo $todo | grep -c "^x "` -eq 0 ] ; then
+        if [ "${todo:0:2}" != "x " ]; then
             now=`date '+%Y-%m-%d'`
             # remove priority once item is done
             sed -i.bak $item"s/^(.) //" "$TODO_FILE"


### PR DESCRIPTION
Found this while reviewing the "nobacktick" pull request. I hope you don't mind all the pull requests, Gina, and find the time to consider them. 

Use simple comparison with slice of string (already used e.g. in _list()) instead of grep -c pipeline.
