### PR TITLE
Use $TODO_ACTIONS_DIR instead of hard-coded directory in the birdseye plugin

### DIFF
--- a/.todo.actions.d/birdseye
+++ b/.todo.actions.d/birdseye
@@ -12,5 +12,5 @@ shift
 }
 
 [ "$action" = "birdseye" ] && {
-     python ~/.todo.actions.d/birdseye.py "$TODO_FILE" "$DONE_FILE"
+     python ${TODO_ACTIONS_DIR}/birdseye.py "$TODO_FILE" "$DONE_FILE"
 }


### PR DESCRIPTION
The birdseye plugin has the actions directory hard coded. This patch makes the plugin use $TODO_ACTIONS_DIR instead of the hard-coded directory (~/.todo.actions.d/) to find the birdseye.py python script.

[ BTW, todo.txt is AWESOME! ;-) ]
