### PR TITLE
Add test to enforce use of $(...) code style in todo.sh.

### DIFF
--- a/tests/t0100-code-nobacktick.sh
+++ b/tests/t0100-code-nobacktick.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+test_description='no old-style backtick command substitution
+
+This test checks the todo.sh script itself for occurrences
+of old-style backtick command substitution, which should be
+replaced with $(...).
+'
+. ./test-lib.sh
+
+test_todo_session 'no old-style backtick command substitution' <<EOF
+>>> sed -n -e 's/[ \t]#.*//' -e '/\d96/{=;p}' "$(which todo.sh)"
+EOF
+
+test_done

--- a/todo.sh
+++ b/todo.sh
@@ -620,7 +620,7 @@ _addto() {
 
     if [[ $TODOTXT_DATE_ON_ADD = 1 ]]; then
         now=$(date '+%Y-%m-%d')
-        input=`echo "$input" | sed -e 's/^\(([A-Z]) \)\{0,1\}/\1'"$now /"`
+        input=$(echo "$input" | sed -e 's/^\(([A-Z]) \)\{0,1\}/\1'"$now /")
     fi
     echo "$input" >> "$file"
     if [ $TODOTXT_VERBOSE -gt 0 ]; then


### PR DESCRIPTION
Pull request #26 by trajano (e24777fa2cf40d2a50b2) changed `...` to $(...), but the following commit 7900ad7e1b71bee1b828 already added another old-style one. I think the tests can also be used for some simple enforcement of coding style, so here is a first shot at it.
