### PR TITLE
FIX: Correct quoting for negative -TERM filtering.

### DIFF
--- a/tests/t1300-ls.sh
+++ b/tests/t1300-ls.sh
@@ -74,6 +74,29 @@ TODO: 1 of 3 tasks shown
 EOF
 
 #
+# check negative filtering via -TERM
+#
+test_todo_session 'checking negative filtering via -TERM' <<EOF
+>>> todo.sh ls -second
+2 aaa zzz this line should be first.
+1 ccc xxx this line should be third.
+--
+TODO: 2 of 3 tasks shown
+
+>>> todo.sh ls "-should be f"
+3 bbb yyy this line should be second.
+1 ccc xxx this line should be third.
+--
+TODO: 2 of 3 tasks shown
+
+>>> todo.sh ls "- zzz"
+3 bbb yyy this line should be second.
+1 ccc xxx this line should be third.
+--
+TODO: 2 of 3 tasks shown
+EOF
+
+#
 # check the filtering of TERM with regexp
 #
 test_todo_session 'checking filtering of TERM with regexp' <<EOF

--- a/todo.sh
+++ b/todo.sh
@@ -688,7 +688,7 @@ filtercommand()
             ## $search_term
             #
             ## Remove the first character (-) before adding to our filter command
-            filter="${filter:-}${filter:+ | }grep -v -i '$(shellquote "${search_term:1}")'"
+            filter="${filter:-}${filter:+ | }grep -v -i $(shellquote "${search_term:1}")"
         fi
     done
 


### PR DESCRIPTION
This oversight was recently introduced with the new filtercommand() in a0f39480bfcf6f9de95583257cee958bcc7ef594.
I've enhanced the test to cover -TERM filtering, too.
