### PR TITLE
Fixes for archive/ls leading "x" case sensitivity

### DIFF
--- a/tests/t1330-ls-highlighting.sh
+++ b/tests/t1330-ls-highlighting.sh
@@ -148,6 +148,25 @@ TODO: 4 marked as done.
 TODO: 5 of 5 tasks shown
 EOF
 
+# check highlighting of uppercase-X done-but-not-archived tasks
+cat > todo.txt <<EOF
+(A) smell the uppercase Roses +flowers @outside
+X remove1
+notice the sunflowers
+remove2
+stop
+EOF
+test_todo_session 'highlighting of done tasks' <<EOF
+>>> todo.sh list
+[1;33m1 (A) smell the uppercase Roses +flowers @outside[0m
+3 notice the sunflowers
+4 remove2
+5 stop
+[0;37m2 X remove1[0m
+--
+TODO: 5 of 5 tasks shown
+EOF
+
 # check highlighting with hidden contexts/projects
 #
 cat > todo.txt <<EOF

--- a/tests/t1900-archive.sh
+++ b/tests/t1900-archive.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+test_description='archive functionality
+
+Ensure we can append items successfully.
+'
+. ./test-lib.sh
+
+cat >> todo.txt<<EOF
+x smell them quietly
+EOF
+
+test_todo_session 'archive lowercase x' <<EOF
+>>> todo.sh archive
+x smell them quietly
+TODO: $HOME/todo.txt archived.
+EOF
+
+cat > todo.txt <<EOF
+notice the daisies
+X smell the roses
+EOF
+
+test_todo_session 'archive uppercase X' <<EOF
+>>> todo.sh archive
+X smell the roses
+TODO: $HOME/todo.txt archived.
+EOF
+
+test_done

--- a/todo.sh
+++ b/todo.sh
@@ -357,9 +357,9 @@ archive()
 {
     #defragment blank lines
     sed -i.bak -e '/./!d' "$TODO_FILE"
-    [ $TODOTXT_VERBOSE -gt 0 ] && grep "^x " "$TODO_FILE"
-    grep "^x " "$TODO_FILE" >> "$DONE_FILE"
-    sed -i.bak '/^x /d' "$TODO_FILE"
+    [ $TODOTXT_VERBOSE -gt 0 ] && grep -i "^x " "$TODO_FILE"
+    grep -i "^x " "$TODO_FILE" >> "$DONE_FILE"
+    sed -i.bak '/^[xX] /d' "$TODO_FILE"
     cp "$TODO_FILE" "$TMP_FILE"
     sed -n 'G; s/\n/&&/; /^\([ ~-]*\n\).*\n\1/d; s/\n//; h; P' "$TMP_FILE" > "$TODO_FILE"
     if [ $TODOTXT_VERBOSE -gt 0 ]; then
@@ -800,7 +800,7 @@ _list() {
                 return color
             }
             {
-                if (match($0, /^[0-9]+ x /)) {
+                if (match($0, /^[0-9]+ [xX] /)) {
                     print highlight("COLOR_DONE") $0 highlight("DEFAULT")
                 } else if (match($0, /^[0-9]+ \([A-Z]\)[[:space:]]/)) {
                     clr = highlight("PRI_" substr($0, RSTART + RLENGTH - 3, 1))


### PR DESCRIPTION
As mentioned [on the list](http://tech.groups.yahoo.com/group/todotxt/message/3736), the docs state that the leading "x" for "done" is case-insensitive. `todo.sh archive` disagrees.

Also noted that `todo.sh ls` doesn't highlight uppercase-X items as done. That fix is here, as well.  
