### PR TITLE
Avoid external TR when replacing , with space.

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -991,7 +991,7 @@ case $action in
 
     # Split multiple depri's, if comma separated change to whitespace separated
     # Loop the 'depri' function for each item
-    for item in $(echo $* | tr ',' ' '); do
+    for item in ${*//,/ }; do
         getTodo "$item"
 
 	if [[ "$todo" = \(?\)\ * ]]; then
@@ -1015,7 +1015,7 @@ case $action in
 
     # Split multiple do's, if comma separated change to whitespace separated
     # Loop the 'do' function for each item
-    for item in $(echo $* | tr ',' ' '); do
+    for item in ${*//,/ }; do
         getTodo "$item"
 
         # Check if this item has already been done


### PR DESCRIPTION
No need for an external tool, Bash can do a global literal substitution itself.
