### PR TITLE
Completion better date hide

### DIFF
--- a/todo_completion
+++ b/todo_completion
@@ -45,12 +45,15 @@ _todo()
                             # todo.txt option for that yet.
                             # But keep priority and "x"; they're short and may
                             # provide useful context.
+                            # Remove any trailing whitespace; the Bash
+                            # completion inserts a trailing space itself.
                             # Finally, limit the output to a single line just as
                             # a safety check of the ls action output.
                             local todo=$( \
                                 TODOTXT_VERBOSE=0 todo.sh -@ -+ -p -x command ls "^ *${cur} " | \
                                 sed -e 's/^ *[0-9]\+ //' -e 's/\((.) \)[0-9]\{2,4\}-[0-9]\{2\}-[0-9]\{2\} /\1/' \
                                     -e 's/\([xX] \)\([0-9]\{2,4\}-[0-9]\{2\}-[0-9]\{2\} \)\{1,2\}/\1/' \
+                                    -e 's/[[:space:]]*$//' \
                                     -e '1q' \
                             )
                             # Append task text as a shell comment. This


### PR DESCRIPTION
I found some small deficiencies in the new todo_completion: 
Remove task date(s) when completing prioritized and done tasks and strip trailing whitespace when completing tasks.
