### PR TITLE
Optimization: Put grep -v empty task filter inside sed.

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -785,12 +785,12 @@ _list() {
     fi
     items=$(
         sed = "$src"                                            \
-        | sed '''
+        | sed -e '''
             N
             s/^/     /
             s/ *\([ 0-9]\{'"$PADDING"',\}\)\n/\1 /
-	  '''                                                 \
-        | grep -v "^[ 0-9]\+ *$"
+            /^[ 0-9]\{1,\} *$/d
+         '''
     )
     if [ "${filter_command}" ]; then
         filtered_items=$(echo -n "$items" | eval "${filter_command}")


### PR DESCRIPTION
Second try... I think I've found and fixed the previous issue that caused test failures on OS X (but could test only on the similar BSD). 

The sed on OS X does not understand the + bound, only in the form of + when used with -E. Instead, I chose to fall back to the {1,} basic regexp, in the hope that it is very portable, and to avoid introducing extended regexps to the script.
