### PR TITLE
ENH: Allow listpri filtering with priority ranges.

### DIFF
--- a/tests/t1250-listpri.sh
+++ b/tests/t1250-listpri.sh
@@ -62,6 +62,42 @@ TODO: 0 of 5 tasks shown
 EOF
 
 cat > todo.txt <<EOF
+(B) smell the uppercase Roses +flowers @outside
+(X) clean the house from A-Z
+(C) notice the sunflowers
+(X) listen to music
+buy more records from artists A-Z
+EOF
+test_todo_session 'listpri filtering priority ranges' <<EOF
+>>> todo.sh -p listpri a-c
+1 (B) smell the uppercase Roses +flowers @outside
+3 (C) notice the sunflowers
+--
+TODO: 2 of 5 tasks shown
+
+>>> todo.sh -p listpri c-Z
+3 (C) notice the sunflowers
+2 (X) clean the house from A-Z
+4 (X) listen to music
+--
+TODO: 3 of 5 tasks shown
+
+>>> todo.sh -p listpri A-
+2 (X) clean the house from A-Z
+--
+TODO: 1 of 5 tasks shown
+
+>>> todo.sh -p listpri A-C A-Z
+--
+TODO: 0 of 5 tasks shown
+
+>>> todo.sh -p listpri X A-Z
+2 (X) clean the house from A-Z
+--
+TODO: 1 of 5 tasks shown
+EOF
+
+cat > todo.txt <<EOF
 (B) ccc xxx this line should be third.
 ccc xxx this line should be third.
 (A) aaa zzz this line should be first.

--- a/todo.sh
+++ b/todo.sh
@@ -59,7 +59,7 @@ shorthelp()
 		    listall|lsa [TERM...]
 		    listcon|lsc
 		    listfile|lf [SRC [TERM...]]
-		    listpri|lsp [PRIORITY] [TERM...]
+		    listpri|lsp [PRIORITIES] [TERM...]
 		    listproj|lsprj [TERM...]
 		    move|mv ITEM# DEST [SRC]
 		    prepend|prep ITEM# "TEXT TO PREPEND"
@@ -231,10 +231,11 @@ help()
 		      Without any arguments, the names of all text files in the todo.txt
 		      directory are listed.
 		
-		    listpri [PRIORITY] [TERM...]
-		    lsp [PRIORITY] [TERM...]
-		      Displays all tasks prioritized PRIORITY.
-		      If no PRIORITY specified, lists all prioritized tasks.
+		    listpri [PRIORITIES] [TERM...]
+		    lsp [PRIORITIES] [TERM...]
+		      Displays all tasks prioritized PRIORITIES.
+		      PRIORITIES can be a single one (A) or a range (A-C).
+		      If no PRIORITIES specified, lists all prioritized tasks.
 		      If TERM specified, lists only prioritized tasks that contain TERM(s).
 		      Hides all tasks that contain TERM(s) preceded by a minus sign
 		      (i.e. -TERM).  
@@ -1124,8 +1125,8 @@ case $action in
 "listpri" | "lsp" )
     shift ## was "listpri", new $1 is priority to list or first TERM
 
-    pri=$(printf "%s\n" "$1" | tr 'a-z' 'A-Z' | grep '^[A-Z]$') && shift || pri="[A-Z]"
-    post_filter_command="grep '^ *[0-9]\+ (${pri}) '"
+    pri=$(printf "%s\n" "$1" | tr 'a-z' 'A-Z' | grep -e '^[A-Z]$' -e '^[A-Z]-[A-Z]$') && shift || pri="A-Z"
+    post_filter_command="grep '^ *[0-9]\+ ([${pri}]) '"
     _list "$TODO_FILE" "$@"
     ;;
 


### PR DESCRIPTION
So far, the listpri action only supports a single priority. Allowing priority ranges (e.g. todo.sh listpri A-C @work) is a simple but useful enhancement.

Note: The syntax extension only clashes with the [TERM] filtering in a few corner cases, and this can be worked around (e.g. "todo.sh listpri A-Z A-Z" lists all prioritized tasks containing the text A-Z).
