### PR TITLE
Revert to safer POSIX AWK regexp.

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -826,7 +826,7 @@ _format()
             {
                 if (match($0, /^[0-9]+ x /)) {
                     print highlight("COLOR_DONE") $0 highlight("DEFAULT")
-                } else if (match($0, /^[0-9]+ \([A-Z]\)[[:space:]]/)) {
+                } else if (match($0, /^[0-9]+ \([A-Z]\) /)) {
                     clr = highlight("PRI_" substr($0, RSTART + RLENGTH - 3, 1))
                     print \
                         (clr ? clr : highlight("PRI_X")) \


### PR DESCRIPTION
AWK from Ubuntu 8.04 (mawk) doesn't support [[:space:]]; so for backwards compatibility use a plain ASCII space instead.

Cp. discussion at http://tech.groups.yahoo.com/group/todotxt/message/3962
