### PR TITLE
Config backtick check

### DIFF
--- a/tests/t0100-code-nobacktick.sh
+++ b/tests/t0100-code-nobacktick.sh
@@ -16,6 +16,8 @@ backtick_check()
 
 test_todo_session 'no old-style backtick command substitution' <<EOF
 >>> backtick_check bin/todo.sh
+
+>>> backtick_check ../../todo.cfg
 EOF
 
 test_done

--- a/todo.cfg
+++ b/todo.cfg
@@ -2,7 +2,7 @@
 
 # Your todo.txt directory
 #export TODO_DIR="/Users/gina/Documents/todo"
-export TODO_DIR=`dirname "$0"`
+export TODO_DIR=$(dirname "$0")
 
 # Your todo/done/report.txt locations
 export TODO_FILE="$TODO_DIR/todo.txt"


### PR DESCRIPTION
This was just raised on the mailing list: For consistency, also use $(...) instead of `...` in todo.cfg, and ensure this in the existing test.
