### PR TITLE
FIX: todo_completion problem with Bash 3.1

### DIFF
--- a/todo_completion
+++ b/todo_completion
@@ -14,14 +14,15 @@ _todo()
         rm depri dp do help list ls listaddons listall lsa listcon  \
         lsc listfile lf listpri lsp listproj lsprj move \
         mv prepend prep pri p replace report shorthelp"
+    local -r MOVE_COMMAND_PATTERN='^(move|mv)$'
 
     local _todo_sh=${_todo_sh:-todo.sh}
     local completions
     if [ $COMP_CWORD -eq 1 ]; then
         completions="$COMMANDS $(eval TODOTXT_VERBOSE=0 $_todo_sh command listaddons) $OPTS"
     elif [[ $COMP_CWORD -gt 2 && ( \
-        "${COMP_WORDS[COMP_CWORD-2]}" =~ ^(move|mv)$ || \
-        "${COMP_WORDS[COMP_CWORD-3]}" =~ ^(move|mv)$ ) ]]; then
+        "${COMP_WORDS[COMP_CWORD-2]}" =~ $MOVE_COMMAND_PATTERN || \
+        "${COMP_WORDS[COMP_CWORD-3]}" =~ $MOVE_COMMAND_PATTERN ) ]]; then
         # "move ITEM# DEST [SRC]" has file arguments on positions 2 and 3.
         completions=$(eval TODOTXT_VERBOSE=0 $_todo_sh command listfile)
     else


### PR DESCRIPTION
Regexp matching changed from 3.1 to 3.2. Make it work for Bash 3.1 by using an intermediate variable, as in 394c4c748ac7fe9c4840536eb1ac28aa9a03853f.
Cp. http://tech.groups.yahoo.com/group/todotxt/message/4211
