### PR TITLE
Make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 #
 # Makefile for todo.txt
 #
+INSTALL_DIR=/usr/local/bin
 
 # Dynamically detect/generate version file as necessary
 # This file will define a variable called VERSION.
@@ -29,6 +30,12 @@ dist: $(DISTFILES) todo.sh
 clean:
 	rm -f $(DISTNAME).tar.gz $(DISTNAME).zip
 
+install:
+	cp todo.sh $(INSTALL_DIR)/todo
+	chmod a+x $(INSTALL_DIR)/todo
+	cp todo_completion /etc/bash_completion.d/todo
+	mkdir -p ~/.todo
+	cp -n todo.cfg ~/.todo/config 
 
 #
 # Testing


### PR DESCRIPTION
Automates the setup process. with this, you can do complete setup with 

$ git clone git://github.com/danohuiginn/todo.txt-cli.git
$ cd todo.txt-cli
$ sudo make install

Did this for my own benefit; if you actually want to include it, I'm happy to add documentation, make it more robust, etc. Currently works on ubuntu; assume it'll be OK on other linuxes, not sure about macs.
