### PR TITLE
Fix shorthelp custom config

### DIFF
--- a/tests/t2120-shorthelp.sh
+++ b/tests/t2120-shorthelp.sh
@@ -40,23 +40,35 @@ EOF
 # Verify that custom configuration is actually processed (when the -d option
 # precedes the -h option) by specifying a different actions directory and moving
 # our custom action there. The help output should mention the "Add-On Actions".
+set -o pipefail # So that the sed filter doesn't swallow todo.sh's exit code.
 mv todo.cfg custom.cfg
 mv .todo.actions.d custom.actions
 echo 'export TODO_ACTIONS_DIR=$HOME/custom.actions' >> custom.cfg
 
-test_todo_session '-h fatal error without config' <<EOF
->>> todo.sh -h
-Fatal Error: Cannot read configuration file $HOME/.todo/config
-=== 1
-EOF
-test_todo_session '-h fatal error with trailing custom config' <<EOF
->>> todo.sh -h -d custom.cfg
+test_todo_session '-h and fatal error without config' <<EOF
+>>> todo.sh -h | sed '/^ \\{0,2\\}[A-Z]/!d'
+  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Actions:
+  Actions can be added and overridden using scripts in the actions
+  See "help" for more details.
 Fatal Error: Cannot read configuration file $HOME/.todo/config
 === 1
 EOF
 
+# Config option comes too late; "Add-on Actions" is *not* mentioned here.
+test_todo_session '-h and fatal error with trailing custom config' <<EOF
+>>> todo.sh -h -d custom.cfg | sed '/^ \\{0,2\\}[A-Z]/!d'
+  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Actions:
+  Actions can be added and overridden using scripts in the actions
+  See "help" for more details.
+Fatal Error: Cannot read configuration file $HOME/.todo/config
+=== 1
+EOF
+
+# Config option processed; "Add-on Actions" is mentioned here.
 test_todo_session '-h output with preceding custom config' <<EOF
->>> todo.sh -d custom.cfg -h | sed '/^  [A-Z]/!d'
+>>> todo.sh -d custom.cfg -h | sed '/^ \\{0,2\\}[A-Z]/!d'
   Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
   Actions:
   Actions can be added and overridden using scripts in the actions

--- a/todo.sh
+++ b/todo.sh
@@ -81,7 +81,6 @@ shorthelp()
 
 		  See "help" for more details.
 	EndHelpFooter
-    exit 0
 }
 
 help()
@@ -327,6 +326,16 @@ actionUsage()
     done
 }
 
+dieWithHelp()
+{
+    case "$1" in
+        help)       help;;
+        shorthelp)  shorthelp;;
+    esac
+    shift
+
+    die "$@"
+}
 die()
 {
     echo "$*"
@@ -655,7 +664,7 @@ fi
 }
 
 # === SANITY CHECKS (thanks Karl!) ===
-[ -r "$TODOTXT_CFG_FILE" ] || die "Fatal Error: Cannot read configuration file $TODOTXT_CFG_FILE"
+[ -r "$TODOTXT_CFG_FILE" ] || dieWithHelp "$1" "Fatal Error: Cannot read configuration file $TODOTXT_CFG_FILE"
 
 . "$TODOTXT_CFG_FILE"
 
@@ -694,8 +703,8 @@ fi
 ACTION=${1:-$TODOTXT_DEFAULT_ACTION}
 
 [ -z "$ACTION" ]    && usage
-[ -d "$TODO_DIR" ]  || die "Fatal Error: $TODO_DIR is not a directory"
-( cd "$TODO_DIR" )  || die "Fatal Error: Unable to cd to $TODO_DIR"
+[ -d "$TODO_DIR" ]  || dieWithHelp "$1" "Fatal Error: $TODO_DIR is not a directory"
+( cd "$TODO_DIR" )  || dieWithHelp "$1" "Fatal Error: Unable to cd to $TODO_DIR"
 
 [ -f "$TODO_FILE" ] || cp /dev/null "$TODO_FILE"
 [ -f "$DONE_FILE" ] || cp /dev/null "$DONE_FILE"


### PR DESCRIPTION
This fixes #93, adds test coverage for `-h` and `shorthelp`, and as a bonus enables -h output even when todo.txt complains about a fatal error.

Tested on Ubuntu 10.04 and Cygwin.
