### PR TITLE
Add CONTRIBUTING for GitHub integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# DO NOT ENTER AN ISSUE UNTIL IT'S BEEN VERIFIED
+
 Please do not enter feature requests or bug reports here until you have joined the mailing list and submitted it there for verification and discussion first.
 
 http://tech.groups.yahoo.com/group/todotxt/


### PR DESCRIPTION
As a thank you for maintaining `todo.sh`, I thought I'd add a `CONTRIBUTING` file.

GitHub recently added issue integration for `CONTRIBUTING` files.  If one is present in a repository, a yellow bar with a link and the words "Please review the guidelines for contributing to this repository" will show for anyone who starts to create a new issue.  For an example, you can see how it works for the [Maid project that I maintain](https://github.com/benjaminoakes/maid):

Example: https://github.com/benjaminoakes/maid/issues/new

I based the content for the `todo.txt-cli` `CONTRIBUTING` file on issue #15.

I hope this helps!  Thanks again for maintaining this project.

Ben
