### PR TITLE
Allow the use of a global config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ clean:
 install:
 	install --mode=755 todo.sh $(INSTALL_DIR)
 	install --mode=644 todo_completion /etc/bash_completion.d/todo
-	mkdir -p ~/.todo
-	cp -n todo.cfg ~/.todo/config 
-
+	mkdir -p /etc/todo
+	[ -e /etc/todo/config ] || \
+		sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > /etc/todo/config
 #
 # Testing
 #

--- a/tests/t0000-config.sh
+++ b/tests/t0000-config.sh
@@ -8,6 +8,10 @@ to find it somewhere else.
 '
 . ./test-lib.sh
 
+
+# Override default global config file
+export TODOTXT_GLOBAL_CFG_FILE=global.cfg
+
 # Remove the pre-created todo.cfg to test behavior in its absence
 rm -f todo.cfg
 echo "Fatal Error: Cannot read configuration file $HOME/.todo/config" > expect
@@ -53,6 +57,14 @@ test_expect_success 'config file (default location 3)' '
     todo.sh > output;
     test_cmp expect output && test -f used_config &&
         rm -f .todo.cfg
+'
+
+rm -f used_config
+test_expect_success 'config file (global config file)' '
+    cp test.cfg "$TODOTXT_GLOBAL_CFG_FILE"
+    todo.sh > output;
+    test_cmp expect output && test -f used_config &&
+        rm -f "$TODOTXT_GLOBAL_CFG_FILE"
 '
 
 rm -f used_config

--- a/tests/t2120-shorthelp.sh
+++ b/tests/t2120-shorthelp.sh
@@ -45,6 +45,9 @@ mv todo.cfg custom.cfg
 mv .todo.actions.d custom.actions
 echo 'export TODO_ACTIONS_DIR=$HOME/custom.actions' >> custom.cfg
 
+# Avoid the use of global config file, if it exists
+export TODOTXT_GLOBAL_CFG_FILE=global.cfg
+
 test_todo_session '-h and fatal error without config' <<EOF
 >>> todo.sh -h | sed '/^ \\{0,2\\}[A-Z]/!d'
   Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]

--- a/todo.sh
+++ b/todo.sh
@@ -584,6 +584,7 @@ TODOTXT_DEFAULT_ACTION=${TODOTXT_DEFAULT_ACTION:-}
 TODOTXT_SORT_COMMAND=${TODOTXT_SORT_COMMAND:-env LC_COLLATE=C sort -f -k2}
 TODOTXT_DISABLE_FILTER=${TODOTXT_DISABLE_FILTER:-}
 TODOTXT_FINAL_FILTER=${TODOTXT_FINAL_FILTER:-cat}
+TODOTXT_GLOBAL_CFG_FILE=${TODOTXT_GLOBAL_CFG_FILE:-/etc/todo/config}
 
 # Export all TODOTXT_* variables
 export ${!TODOTXT_@}
@@ -650,6 +651,15 @@ export SENTENCE_DELIMITERS=',.:;'
     fi
 }
 
+[ -e "$TODOTXT_CFG_FILE" ] || {
+    CFG_FILE_ALT="$TODOTXT_GLOBAL_CFG_FILE"
+
+    if [ -e "$CFG_FILE_ALT" ]
+    then
+        TODOTXT_CFG_FILE="$CFG_FILE_ALT"
+    fi
+}
+
 
 if [ -z "$TODO_ACTIONS_DIR" -o ! -d "$TODO_ACTIONS_DIR" ]
 then
@@ -706,7 +716,7 @@ fi
 ACTION=${1:-$TODOTXT_DEFAULT_ACTION}
 
 [ -z "$ACTION" ]    && usage
-[ -d "$TODO_DIR" ]  || dieWithHelp "$1" "Fatal Error: $TODO_DIR is not a directory"
+[ -d "$TODO_DIR" ]  || mkdir -p $TODO_DIR 2> /dev/null || dieWithHelp "$1" "Fatal Error: $TODO_DIR is not a directory"
 ( cd "$TODO_DIR" )  || dieWithHelp "$1" "Fatal Error: Unable to cd to $TODO_DIR"
 
 [ -f "$TODO_FILE" ] || cp /dev/null "$TODO_FILE"


### PR DESCRIPTION
- Look for the config file in `/etc/todo/config`, if not found elsewhere
- `make install` installs a global config file, setting `TODO_DIR=~/.todo`.
- `todo.sh` creates `TODO_DIR` if it doesn't exist.
- `make install` installs `todo.sh` instead of `todo`.
