### PR TITLE
Print newline at the end of the items.

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -852,7 +852,7 @@ _format()
         filtered_items=$items
     fi
     filtered_items=$(
-        echo -n "$filtered_items"                              \
+        echo "$filtered_items"                              \
         | sed '''
             s/^     /00000/;
             s/^    /0000/;


### PR DESCRIPTION
Sort filters could produce incorrect output. When an item at the bottom of todo.txt (without trailing newline) gets sorted, the next item in order could end up on the same line.

Just let echo print that final newline, instead of letting each sort filter append missing newlines.

All 427 tests were executed successfully, task counts are still OK.
