### PR TITLE
Colorized replace output

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -444,9 +444,9 @@ replaceOrPrepend()
     getNewtodo "$item"
     case "$action" in
       replace)
-        echo "$item $todo"
-        echo "TODO: Replaced task with:"
-        echo "$item $newtodo"
+        echo "TODO: Replaced task #$item"
+        echo -e "\x1b[31;1m- $todo\x1b[0m"
+        echo -e "\x1b[32;1m+ $newtodo\x1b[0m"
         ;;
       prepend)
         echo "$item $newtodo"


### PR DESCRIPTION
before:

```
17 (A) lorem ipsum
TODO: Replaced task with:
17 (A) lorem foo ipsum
```

after:

``` diff
TODO: Replaced task #17
- (A) lorem ipsum
+ (A) lorem foo ipsum
```

(close approximation)

this is a personal modification and I'm not at all convinced that it belongs into the general distro (not everyone appreciates ANSI escapes, suitable colors depend on terminal configuration, diff-like output might be too developer-centric) - but I figured I'd share it just in case

I suppose the Right Way™ would be to refactor `todo.sh` to encapsulate reporting so a plugin could overwrite it, but that seemed like overkill
