### PR TITLE
Fix changelog link in readme

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -23,5 +23,5 @@ h2. Quick Links
 * Licensed under the "GPL":http://www.gnu.org/copyleft/gpl.html
 * "Add-on Directory":https://github.com/ginatrapani/todo.txt-cli/wiki/Todo.sh-Add-on-Directory
 https://github.com/ginatrapani/todo.txt-cli/wiki/Creating-and-Installing-Add-ons
-* "Changelog":http://wiki.github.com/ginatrapani/todo.txt-cli/todosh-changelog
+* "Changelog":https://github.com/ginatrapani/todo.txt-cli/wiki/Todo.sh-Changelog
 * "Known Bugs":http://github.com/ginatrapani/todo.txt-cli/issues


### PR DESCRIPTION
Clicking the readme link in the changelog brought up a blank wiki editor for me. This appears to be the correct address.
