### PR TITLE
Make "do" save priority by adding a prio: tag at the end.

### DIFF
--- a/tests/t9999-testsuite_example.sh
+++ b/tests/t9999-testsuite_example.sh
@@ -36,14 +36,14 @@ TODO: 2 of 4 tasks shown
 TODO: 1 of 4 tasks shown
 
 >>> todo.sh -a do 2
-2 x 2009-02-13 notice the sunflowers
+2 x 2009-02-13 notice the sunflowers prio:A
 TODO: 2 marked as done.
 
 >>> todo.sh -p list
 1 (B) smell the uppercase Roses +flowers @outside
 4 smell the coffee +wakeup
 3 stop
-2 x 2009-02-13 notice the sunflowers
+2 x 2009-02-13 notice the sunflowers prio:A
 --
 TODO: 4 of 4 tasks shown
 
@@ -67,12 +67,12 @@ TODO: 6 added.
 4 smell the coffee +wakeup
 3 stop
 6 visit http://example.com
-2 x 2009-02-13 notice the sunflowers
+2 x 2009-02-13 notice the sunflowers prio:A
 --
 TODO: 6 of 6 tasks shown
 
 >>> todo.sh archive
-x 2009-02-13 notice the sunflowers
+x 2009-02-13 notice the sunflowers prio:A
 TODO: $HOME/todo.txt archived.
 
 >>> todo.sh -p list

--- a/tests/t9999-testsuite_example.sh
+++ b/tests/t9999-testsuite_example.sh
@@ -36,14 +36,14 @@ TODO: 2 of 4 tasks shown
 TODO: 1 of 4 tasks shown
 
 >>> todo.sh -a do 2
-2 x 2009-02-13 notice the sunflowers prio:A
+2 x 2009-02-13 notice the sunflowers pri:A
 TODO: 2 marked as done.
 
 >>> todo.sh -p list
 1 (B) smell the uppercase Roses +flowers @outside
 4 smell the coffee +wakeup
 3 stop
-2 x 2009-02-13 notice the sunflowers prio:A
+2 x 2009-02-13 notice the sunflowers pri:A
 --
 TODO: 4 of 4 tasks shown
 
@@ -67,12 +67,12 @@ TODO: 6 added.
 4 smell the coffee +wakeup
 3 stop
 6 visit http://example.com
-2 x 2009-02-13 notice the sunflowers prio:A
+2 x 2009-02-13 notice the sunflowers pri:A
 --
 TODO: 6 of 6 tasks shown
 
 >>> todo.sh archive
-x 2009-02-13 notice the sunflowers prio:A
+x 2009-02-13 notice the sunflowers pri:A
 TODO: $HOME/todo.txt archived.
 
 >>> todo.sh -p list

--- a/todo.sh
+++ b/todo.sh
@@ -1160,7 +1160,7 @@ case $action in
         if [ "${todo:0:2}" != "x " ]; then
             now=$(date '+%Y-%m-%d')
             # reformat priority once item is done
-            sed -i.bak $item's/^(\(.\)) \(.*$\)/\2 prio:\1/' "$TODO_FILE"
+            sed -i.bak $item's/^(\(.\)) \(.*$\)/\2 pri:\1/' "$TODO_FILE"
             sed -i.bak $item"s|^|x $now |" "$TODO_FILE"
             if [ $TODOTXT_VERBOSE -gt 0 ]; then
                 getNewtodo "$item"

--- a/todo.sh
+++ b/todo.sh
@@ -1159,8 +1159,8 @@ case $action in
         # Check if this item has already been done
         if [ "${todo:0:2}" != "x " ]; then
             now=$(date '+%Y-%m-%d')
-            # remove priority once item is done
-            sed -i.bak $item"s/^(.) //" "$TODO_FILE"
+            # reformat priority once item is done
+            sed -i.bak $item's/^(\(.\)) \(.*$\)/\2 prio:\1/' "$TODO_FILE"
             sed -i.bak $item"s|^|x $now |" "$TODO_FILE"
             if [ $TODOTXT_VERBOSE -gt 0 ]; then
                 getNewtodo "$item"


### PR DESCRIPTION
there was a discussion... subject "Simple Tasks and Priorities" on March 26th and a day or two after.
It seemed to say that when deleting a task, it would be better to keep the priority with a prio: tag.
So this patch implements that.

There is a one-line mod to the main script, but most of the patch relates to updating the tests.

passes all tests, after they are adjusted for the new behaviour.
