### PR TITLE
Default to user writable directory in config

### DIFF
--- a/todo.cfg
+++ b/todo.cfg
@@ -2,7 +2,7 @@
 
 # Your todo.txt directory
 #export TODO_DIR="/Users/gina/Documents/todo"
-export TODO_DIR=$(dirname "$0")
+export TODO_DIR=${HOME:-$USERPROFILE}
 
 # Your todo/done/report.txt locations
 export TODO_FILE="$TODO_DIR/todo.txt"


### PR DESCRIPTION
When a user installs from a package manager ([MacPorts](https://www.macports.org), [Homebrew](http://brew.sh),
`yum`, etc.), the `todo.sh` script is installed into a restricted
folder.  This means that the result of `$(basename "$0")` is a directory
where the user cannot write without elevated permissions.  This
generates additional noise when the user first runs `todo.sh -h`.  An
alternative is to default to the user's personal directory which is
known to exist and will be writable by the user.
