### PR TITLE
Set the executable bit when preparing releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ dist: $(DISTFILES) todo.sh
 	mkdir -p $(DISTNAME)
 	cp -f $(DISTFILES) $(DISTNAME)/
 	sed -e 's/@DEV_VERSION@/'$(VERSION)'/' todo.sh > $(DISTNAME)/todo.sh
+	chmod +x $(DISTNAME)/todo.sh
 	tar cf $(DISTNAME).tar $(DISTNAME)/
 	gzip -f -9 $(DISTNAME).tar
 	zip -9r $(DISTNAME).zip $(DISTNAME)/


### PR DESCRIPTION
This means that people who download todo.sh don't have to `chmod +x` themselves - which is nice because it simplifies the install instructions a bit.

If I were you, I'd do a new release after this change, but I've left it out of this PR since I wasn't sure if you wanted that. I'm happy to add a commit bumping the version, if you want to keep it all in one PR (or whatever).
