### PR TITLE
interpreter reference updated to be portable

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 # === HEAVY LIFTING ===
 shopt -s extglob extquote


### PR DESCRIPTION
Just change a `#!/bin/bash` to `#!/usr/bin/env bash` for a portability. Now runs on OpenBSD without errors.
