### PR TITLE
Remove newline from echo confirmation on `todo rm`

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -1081,7 +1081,7 @@ case $action in
 
     if [ -z "$3" ]; then
         if  [ $TODOTXT_FORCE = 0 ]; then
-            echo "Delete '$todo'?  (y/n)"
+            echo -n "Delete '$todo'?  (y/n) "
             read ANSWER
         else
             ANSWER="y"


### PR DESCRIPTION
Seemed to be unintentional as `-n` is used in other places in the script when getting input.
