### PR TITLE
Use local todo.txt for project specific task lists

### DIFF
--- a/todo.cfg
+++ b/todo.cfg
@@ -4,23 +4,12 @@
 #export TODO_DIR="/Users/gina/Documents/todo"
 export TODO_DIR=$(dirname "$0")
 
-# search for todo.txt up the directory tree
-S="${PWD}"
-while [ -n "${S}" ] && [ ! -f "${S}/todo.txt" ]
-do
-    S=${S%/*}
-done
-
-# if found before reaching root, this is the TODO_DIR
-if [ -n "${S}" ]
-then
-    export TODO_DIR="${S}"
-fi
-
-# Your todo/done/report.txt locations
-export TODO_FILE="$TODO_DIR/todo.txt"
-export DONE_FILE="$TODO_DIR/done.txt"
-export REPORT_FILE="$TODO_DIR/report.txt"
+# You can override your todo/done/report.txt locations here.
+# Don't do that, if you have TODOTXT_USE_LOCAL=1
+#
+#export TODO_FILE="$TODO_DIR/todo.txt"
+#export DONE_FILE="$TODO_DIR/done.txt"
+#export REPORT_FILE="$TODO_DIR/report.txt"
 
 # You can customize your actions directory location
 #export TODO_ACTIONS_DIR="$HOME/.todo.actions.d"
@@ -95,3 +84,9 @@ export REPORT_FILE="$TODO_DIR/report.txt"
 # just before the list output is displayed.
 #
 # export TODOTXT_FINAL_FILTER='cat'
+
+# TODOTXT_USE_LOCAL will look for a todo.txt up the directory tree
+# and use this directory as TODO_DIR when found.
+# Useful for project-specific todo lists.
+#
+# export TODOTXT_USE_LOCAL=1

--- a/todo.cfg
+++ b/todo.cfg
@@ -5,7 +5,9 @@
 export TODO_DIR=$(dirname "$0")
 
 # You can override your todo/done/report.txt locations here.
-# Don't do that, if you have TODOTXT_USE_LOCAL=1
+# These will override TODOTXT_USE_LOCAL=1; it doesn't make sense for TODO_FILE,
+# but you could override DONE_FILE / REPORT_FILE in order to
+# collect done tasks / reports globally.
 #
 #export TODO_FILE="$TODO_DIR/todo.txt"
 #export DONE_FILE="$TODO_DIR/done.txt"

--- a/todo.cfg
+++ b/todo.cfg
@@ -4,6 +4,19 @@
 #export TODO_DIR="/Users/gina/Documents/todo"
 export TODO_DIR=$(dirname "$0")
 
+# search for todo.txt up the directory tree
+S="${PWD}"
+while [ -n "${S}" ] && [ ! -f "${S}/todo.txt" ]
+do
+    S=${S%/*}
+done
+
+# if found before reaching root, this is the TODO_DIR
+if [ -n "${S}" ]
+then
+    export TODO_DIR="${S}"
+fi
+
 # Your todo/done/report.txt locations
 export TODO_FILE="$TODO_DIR/todo.txt"
 export DONE_FILE="$TODO_DIR/done.txt"

--- a/todo.sh
+++ b/todo.sh
@@ -489,7 +489,7 @@ OVR_TODOTXT_USE_LOCAL="$TODOTXT_USE_LOCAL"
 GREP_OPTIONS=""
 
 # == PROCESS OPTIONS ==
-while getopts ":fhpcnNaAtTvVx+@Pd:" Option
+while getopts ":fhpcnNaAtTvVx+@PdlL:" Option
 do
   case $Option in
     '@' )

--- a/todo.sh
+++ b/todo.sh
@@ -99,6 +99,12 @@ help()
 		        Color mode
 		    -d CONFIG_FILE
 		        Use a configuration file other than the default ~/.todo/config
+		    -l
+		    	Use a (local) todo.txt that is found in the current directory
+		    	or up the directory tree
+		    -L
+		    	Use global todo.txt from the config file, not the local one
+		    	(default).
 		    -f
 		        Forces actions without confirmation or interactive input
 		    -h
@@ -141,6 +147,7 @@ help()
 		    TODOTXT_AUTO_ARCHIVE            is same as option -a (0)/-A (1)
 		    TODOTXT_CFG_FILE=CONFIG_FILE    is same as option -d CONFIG_FILE
 		    TODOTXT_FORCE=1                 is same as option -f
+		    TODOTXT_USE_LOCAL               is same as option -l (0)/-L (1)
 		    TODOTXT_PRESERVE_LINE_NUMBERS   is same as option -n (0)/-N (1)
 		    TODOTXT_PLAIN                   is same as option -p (1)/-c (0)
 		    TODOTXT_DATE_ON_ADD             is same as option -t (1)/-T (0)
@@ -476,6 +483,7 @@ OVR_TODOTXT_VERBOSE="$TODOTXT_VERBOSE"
 OVR_TODOTXT_DEFAULT_ACTION="$TODOTXT_DEFAULT_ACTION"
 OVR_TODOTXT_SORT_COMMAND="$TODOTXT_SORT_COMMAND"
 OVR_TODOTXT_FINAL_FILTER="$TODOTXT_FINAL_FILTER"
+OVR_TODOTXT_USE_LOCAL="$TODOTXT_USE_LOCAL"
 
 # Prevent GREP_OPTIONS from malforming grep's output
 GREP_OPTIONS=""
@@ -538,6 +546,12 @@ do
         set -- '-h' 'shorthelp'
         OPTIND=2
         ;;
+    l )
+        OVR_TODOTXT_USE_LOCAL=1
+        ;;
+    L )
+        OVR_TODOTXT_USE_LOCAL=0
+        ;;
     n )
         OVR_TODOTXT_PRESERVE_LINE_NUMBERS=0
         ;;
@@ -595,6 +609,7 @@ TODOTXT_SORT_COMMAND=${TODOTXT_SORT_COMMAND:-env LC_COLLATE=C sort -f -k2}
 TODOTXT_DISABLE_FILTER=${TODOTXT_DISABLE_FILTER:-}
 TODOTXT_FINAL_FILTER=${TODOTXT_FINAL_FILTER:-cat}
 TODOTXT_GLOBAL_CFG_FILE=${TODOTXT_GLOBAL_CFG_FILE:-/etc/todo/config}
+TODOTXT_USE_LOCAL=${TODOTXT_USE_LOCAL:-0}
 
 # Export all TODOTXT_* variables
 export ${!TODOTXT_@}
@@ -726,8 +741,27 @@ fi
 if [ -n "$OVR_TODOTXT_FINAL_FILTER" ] ; then
   TODOTXT_FINAL_FILTER="$OVR_TODOTXT_FINAL_FILTER"
 fi
+if [ -n "$OVR_TODOTXT_USE_LOCAL" ] ; then
+  TODOTXT_USE_LOCAL="$OVR_TODOTXT_USE_LOCAL"
+fi
 
 ACTION=${1:-$TODOTXT_DEFAULT_ACTION}
+
+if [ $TODOTXT_USE_LOCAL -gt 0 ]; then
+# search for todo.txt up the directory tree
+	S="${PWD}"
+	while [ -n "${S}" ] && [ ! -f "${S}/todo.txt" ] ; do
+	    S=${S%/*}
+	done
+# if found before reaching root, this is the TODO_DIR
+	if [ -n "${S}" ] ; then
+	    TODO_DIR="${S}"
+	fi
+fi
+
+TODO_FILE=${TODO_FILE:-"$TODO_DIR/todo.txt"}
+DONE_FILE=${DONE_FILE:-"$TODO_DIR/done.txt"}
+REPORT_FILE=${REPORT_FILE:-"$TODO_DIR/report.txt"}
 
 [ -z "$ACTION" ]    && usage
 [ -d "$TODO_DIR" ]  || mkdir -p $TODO_DIR 2> /dev/null || dieWithHelp "$1" "Fatal Error: $TODO_DIR is not a directory"

--- a/todo.sh
+++ b/todo.sh
@@ -489,7 +489,7 @@ OVR_TODOTXT_USE_LOCAL="$TODOTXT_USE_LOCAL"
 GREP_OPTIONS=""
 
 # == PROCESS OPTIONS ==
-while getopts ":fhpcnNaAtTvVx+@PdlL:" Option
+while getopts ":fhpcnNaAlLtTvVx+@Pd:" Option
 do
   case $Option in
     '@' )

--- a/todo.sh
+++ b/todo.sh
@@ -101,7 +101,8 @@ help()
 		        Use a configuration file other than the default ~/.todo/config
 		    -l
 		    	Use a (local) todo.txt that is found in the current directory
-		    	or up the directory tree
+		    	or up the directory tree, falling back to the configured (global)
+				TODO_DIR if no local one is found
 		    -L
 		    	Use global todo.txt from the config file, not the local one
 		    	(default).


### PR DESCRIPTION
I tend to have rather long task lists for single projects filling up my global todo.txt. Although I can tag them with "@my_project" I don't like the confusingly long task list.

So I extracted the project specific task into local todo.txt files, that I can add to the project's git repo. This change to todo.sh makes it search up the directory path for a local todo.txt and use this if it finds any. The default behaviour is unchanged (not looking for local todo.txt), but you can turn on using local task lists with `-l` or `TODOTXT_USE_LOCAL=1`. 
