### PR TITLE
Suppress todo.sh error messages when invoked during completion

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -657,6 +657,15 @@ export SENTENCE_DELIMITERS=',.:;'
 }
 
 [ -e "$TODOTXT_CFG_FILE" ] || {
+    CFG_FILE_ALT="${XDG_CONFIG_HOME:-$HOME/.config}/todo/config"
+
+    if [ -e "$CFG_FILE_ALT" ]
+    then
+        TODOTXT_CFG_FILE="$CFG_FILE_ALT"
+    fi
+}
+
+[ -e "$TODOTXT_CFG_FILE" ] || {
     CFG_FILE_ALT=$(dirname "$0")"/todo.cfg"
 
     if [ -e "$CFG_FILE_ALT" ]
@@ -683,6 +692,15 @@ fi
 
 [ -d "$TODO_ACTIONS_DIR" ] || {
     TODO_ACTIONS_DIR_ALT="$HOME/.todo.actions.d"
+
+    if [ -d "$TODO_ACTIONS_DIR_ALT" ]
+    then
+        TODO_ACTIONS_DIR="$TODO_ACTIONS_DIR_ALT"
+    fi
+}
+
+[ -d "$TODO_ACTIONS_DIR" ] || {
+    TODO_ACTIONS_DIR_ALT="${XDG_CONFIG_HOME:-$HOME/.config}/todo/actions"
 
     if [ -d "$TODO_ACTIONS_DIR_ALT" ]
     then

--- a/todo_completion
+++ b/todo_completion
@@ -103,7 +103,7 @@ complete -F _todo todo.sh
 
 # If you use aliases to use different configuration(s), you need to add and use
 # a wrapper completion function for each configuration if you want to complete
-# fron the actual configured task locations:
+# from the actual configured task locations:
 #alias todo2='todo.sh -d "$HOME/todo2.cfg"'
 #_todo2()
 #{

--- a/todo_completion
+++ b/todo_completion
@@ -19,33 +19,33 @@ _todo()
     local _todo_sh=${_todo_sh:-todo.sh}
     local completions
     if [ $COMP_CWORD -eq 1 ]; then
-        completions="$COMMANDS $(eval TODOTXT_VERBOSE=0 $_todo_sh command listaddons) $OPTS"
+        completions="$COMMANDS $(eval TODOTXT_VERBOSE=0 $_todo_sh command listaddons 2>/dev/null) $OPTS"
     elif [[ $COMP_CWORD -gt 2 && ( \
         "${COMP_WORDS[COMP_CWORD-2]}" =~ $MOVE_COMMAND_PATTERN || \
         "${COMP_WORDS[COMP_CWORD-3]}" =~ $MOVE_COMMAND_PATTERN ) ]]; then
         # "move ITEM# DEST [SRC]" has file arguments on positions 2 and 3.
-        completions=$(eval TODOTXT_VERBOSE=0 $_todo_sh command listfile)
+        completions=$(eval TODOTXT_VERBOSE=0 $_todo_sh command listfile 2>/dev/null)
     else
         case "$prev" in
             command)
                 completions=$COMMANDS;;
             help)
-                completions="$COMMANDS $(eval TODOTXT_VERBOSE=0 $_todo_sh command listaddons)";;
+                completions="$COMMANDS $(eval TODOTXT_VERBOSE=0 $_todo_sh command listaddons 2>/dev/null)";;
             addto|listfile|lf)
-                completions=$(eval TODOTXT_VERBOSE=0 $_todo_sh command listfile);;
-            -*) completions="$COMMANDS $(eval TODOTXT_VERBOSE=0 $_todo_sh command listaddons) $OPTS";;
+                completions=$(eval TODOTXT_VERBOSE=0 $_todo_sh command listfile 2>/dev/null);;
+            -*) completions="$COMMANDS $(eval TODOTXT_VERBOSE=0 $_todo_sh command listaddons 2>/dev/null) $OPTS";;
             *)  case "$cur" in
-                    +*) completions=$(eval TODOTXT_VERBOSE=0 $_todo_sh command listproj)
+                    +*) completions=$(eval TODOTXT_VERBOSE=0 $_todo_sh command listproj 2>/dev/null)
                         COMPREPLY=( $( compgen -W "$completions" -- $cur ))
                         [ ${#COMPREPLY[@]} -gt 0 ] && return 0
                         # Fall back to projects extracted from done tasks.
-                        completions=$(eval 'TODOTXT_VERBOSE=0 TODOTXT_SOURCEVAR=\$DONE_FILE' $_todo_sh command listproj)
+                        completions=$(eval 'TODOTXT_VERBOSE=0 TODOTXT_SOURCEVAR=\$DONE_FILE' $_todo_sh command listproj 2>/dev/null)
                         ;;
-                    @*) completions=$(eval TODOTXT_VERBOSE=0 $_todo_sh command listcon)
+                    @*) completions=$(eval TODOTXT_VERBOSE=0 $_todo_sh command listcon 2>/dev/null)
                         COMPREPLY=( $( compgen -W "$completions" -- $cur ))
                         [ ${#COMPREPLY[@]} -gt 0 ] && return 0
                         # Fall back to contexts extracted from done tasks.
-                        completions=$(eval 'TODOTXT_VERBOSE=0 TODOTXT_SOURCEVAR=\$DONE_FILE' $_todo_sh command listcon)
+                        completions=$(eval 'TODOTXT_VERBOSE=0 TODOTXT_SOURCEVAR=\$DONE_FILE' $_todo_sh command listcon 2>/dev/null)
                         ;;
                     *)  if [[ "$cur" =~ ^[0-9]+$ ]]; then
                             # Remove the (padded) task number; we prepend the
@@ -60,7 +60,7 @@ _todo()
                             # Finally, limit the output to a single line just as
                             # a safety check of the ls action output.
                             local todo=$( \
-                                eval TODOTXT_VERBOSE=0 $_todo_sh '-@ -+ -p -x command ls "^ *${cur} "' | \
+                                eval TODOTXT_VERBOSE=0 $_todo_sh '-@ -+ -p -x command ls "^ *${cur} "' 2>/dev/null | \
                                 sed -e 's/^ *[0-9]\{1,\} //' -e 's/^\((.) \)\{0,1\}[0-9]\{2,4\}-[0-9]\{2\}-[0-9]\{2\} /\1/' \
                                     -e 's/^\([xX] \)\([0-9]\{2,4\}-[0-9]\{2\}-[0-9]\{2\} \)\{1,2\}/\1/' \
                                     -e 's/[[:space:]]*$//' \


### PR DESCRIPTION
The Bash completion invokes `todo.sh` for several completion sources (i.e. addons, projects, contexts). This may (potentially; not in the default configuration) cause error messages. For example, I have a code snippet in the config that warns me about an old `todo.txt` file (when Dropbox silently stopped working and I therefore don't have a fresh copy of the todo list). This warning is nice for general `todo.sh` usage, but it's annoying when attempting command-line completion.
Redirect any stderr output from `todo.sh` during completion to `/dev/null`, as it gets in the way. The error will be seen later after building and executing the command-line, anyway.
