### PR TITLE
Configurable config dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Makefile for todo.txt
 #
 INSTALL_DIR=/usr/local/bin
+CONFIG_DIR=/etc
+BASH_COMPLETION_DIR=/etc/bash_completion.d
 
 # Dynamically detect/generate version file as necessary
 # This file will define a variable called VERSION.
@@ -32,11 +34,13 @@ clean: test-pre-clean
 	rm VERSION-FILE
 
 install:
+	mkdir -p $(INSTALL_DIR)
 	install --mode=755 todo.sh $(INSTALL_DIR)
-	install --mode=644 todo_completion /etc/bash_completion.d/todo
-	mkdir -p /etc/todo
-	[ -e /etc/todo/config ] || \
-		sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > /etc/todo/config
+	mkdir -p $(BASH_COMPLETION_DIR)
+	install --mode=644 todo_completion $(BASH_COMPLETION_DIR)/todo
+	mkdir -p $(CONFIG_DIR)/todo
+	[ -e $(CONFIG_DIR)/todo/config ] || \
+		sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > $(CONFIG_DIR)/todo/config
 #
 # Testing
 #

--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@
 brew install todo-txt
 ```
 
+### Linux
+
+#### Arch linux (AUR)
+
+https://aur.archlinux.org/packages/todotxt-git/
+
+#### From command line
+
+```shell
+make
+make install
+make test
+```
+
+*NOTE:* Makefile defaults to several default paths for installed files. Adjust to your system
+
+- INSTALL_DIR: PATH for executables (default /usr/local/bin)
+- CONFIG_DIR: PATH for todo.txt config
+- BASH_COMPLETION: PATH for autocompletion scripts (default to /etc/bash_completion.d)
+
+Example: For arch linux
+
+```shell
+make install CONFIG_DIR=/etc INSTALL_DIR=/usr/bin BASH_COMPLETION_DIR=/usr/share/bash-completion/completions
+```
+
 ### Download
 Download the latest stable [release](https://github.com/todotxt/todo.txt-cli/releases) for use on your desktop or server.
 


### PR DESCRIPTION
Allow to reconfig install dirs for other distros where those paths did not fit:

See https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=todotxt-git#n28