### PR TITLE
Updated add command to accept lowercase priority

### DIFF
--- a/tests/t1010-add-date.sh
+++ b/tests/t1010-add-date.sh
@@ -22,7 +22,7 @@ TODO: 1 of 1 tasks shown
 EOF
 
 test_todo_session 'cmd line first day with priority' <<EOF
->>> todo.sh -pt add '(a) notice the daisies'
+>>> todo.sh -pt add '(A) notice the daisies'
 2 (A) 2009-02-13 notice the daisies
 TODO: 2 added.
 
@@ -34,6 +34,22 @@ TODO: 2 of 2 tasks shown
 
 >>> todo.sh -npf del 2
 2 (A) 2009-02-13 notice the daisies
+TODO: 2 deleted.
+EOF
+
+test_todo_session 'cmd line first day with lowercase priority' <<EOF
+>>> todo.sh -pt add '(b) notice the daisies'
+2 (B) 2009-02-13 notice the daisies
+TODO: 2 added.
+
+>>> todo.sh -p list
+2 (B) 2009-02-13 notice the daisies
+1 2009-02-13 notice the daisies
+--
+TODO: 2 of 2 tasks shown
+
+>>> todo.sh -npf del 2
+2 (B) 2009-02-13 notice the daisies
 TODO: 2 deleted.
 EOF
 

--- a/tests/t1010-add-date.sh
+++ b/tests/t1010-add-date.sh
@@ -22,7 +22,7 @@ TODO: 1 of 1 tasks shown
 EOF
 
 test_todo_session 'cmd line first day with priority' <<EOF
->>> todo.sh -pt add '(A) notice the daisies'
+>>> todo.sh -pt add '(a) notice the daisies'
 2 (A) 2009-02-13 notice the daisies
 TODO: 2 added.
 

--- a/todo.sh
+++ b/todo.sh
@@ -469,14 +469,13 @@ uppercasePriority()
 {
     # Precondition:  $input contains task text for which to uppercase priority.
     # Postcondition: Modifies $input.
-
     lower=( {a..z} )
     upper=( {A..Z} )
     for ((i=0; i<26; i++))
     do
         upperPriority="${upperPriority};s/^[(]${lower[i]}[)]/(${upper[i]})/"
     done
-    input=$(echo $input | sed $upperPriority)
+    input=$(echo "$input" | sed $upperPriority)
 }
 
 #Preserving environment variables so they don't get clobbered by the config file

--- a/todo.sh
+++ b/todo.sh
@@ -465,6 +465,20 @@ replaceOrPrepend()
   fi
 }
 
+uppercasePriority()
+{
+    # Precondition:  $input contains task text for which to uppercase priority.
+    # Postcondition: Modifies $input.
+
+    lower=( {a..z} )
+    upper=( {A..Z} )
+    for ((i=0; i<26; i++))
+    do
+        upperPriority="${upperPriority};s/^[(]${lower[i]}[)]/(${upper[i]})/"
+    done
+    input=$(echo $input | sed $upperPriority)
+}
+
 #Preserving environment variables so they don't get clobbered by the config file
 OVR_TODOTXT_AUTO_ARCHIVE="$TODOTXT_AUTO_ARCHIVE"
 OVR_TODOTXT_FORCE="$TODOTXT_FORCE"
@@ -773,6 +787,7 @@ _addto() {
     file="$1"
     input="$2"
     cleaninput
+    uppercasePriority
 
     if [[ $TODOTXT_DATE_ON_ADD = 1 ]]; then
         now=$(date '+%Y-%m-%d')


### PR DESCRIPTION
The priority command accepts lowercase priority characters and converts them to uppercase.
```shell
$ todo.sh pri 1 a
1 (A) Task
```

The list priority command also accepts lowercase priority characters.
```shell
$ ./todo.sh listpri a
1 (A) Task
```

The add command does not currently accept lowercase priority characters.
```shell
$ ./todo.sh add "(a) Task"
1 (a) Task
```

This change will allow the add command to accept lowercase priority characters and address the inconsistency across commands.

```shell
$ ./todo.sh add "(a) Task"
1 (A) Task
```