### PR TITLE
Fix the Makefile to work with the install instructions in the README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ INSTALL_DATA = $(INSTALL) -m 644
 prefix = /usr/local
 
 # The directory to install todo.sh in.
-bindir = $(prefix)/bin
+INSTALL_DIR = $(prefix)/bin
 
 # The directory to install the config file in.
-sysconfdir = $(prefix)/etc
+CONFIG_DIR = $(prefix)/etc
 
-datarootdir = $(prefix)/share
+BASH_COMPLETION = $(prefix)/share
 
 # Dynamically detect/generate version file as necessary
 # This file will define a variable called VERSION.
@@ -48,23 +48,23 @@ clean: test-pre-clean
 	rm VERSION-FILE
 
 install: installdirs
-	$(INSTALL_PROGRAM) todo.sh $(DESTDIR)$(bindir)/todo.sh
-	$(INSTALL_DATA) todo_completion $(DESTDIR)$(datarootdir)/bash_completion.d/todo
-	[ -e $(DESTDIR)$(sysconfdir)/todo/config ] || \
-	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > $(DESTDIR)$(sysconfdir)/todo/config
+	$(INSTALL_PROGRAM) todo.sh $(INSTALL_DIR)/todo.sh
+	$(INSTALL_DATA) todo_completion $(BASH_COMPLETION)/bash_completion.d/todo
+	[ -e $(CONFIG_DIR)/todo/config ] || \
+	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > $(CONFIG_DIR)/todo/config
 
 uninstall:
-	rm -f $(DESTDIR)$(bindir)/todo.sh
-	rm -f $(DESTDIR)$(datarootdir)/bash_completion.d/todo
-	rm -f $(DESTDIR)$(sysconfdir)/todo/config
+	rm -f $(INSTALL_DIR)/todo.sh
+	rm -f $(BASH_COMPLETION)/bash_completion.d/todo
+	rm -f $(CONFIG_DIR)/todo/config
 
-	rmdir $(DESTDIR)$(datarootdir)/bash_completion.d
-	rmdir $(DESTDIR)$(sysconfdir)/todo
+	rmdir $(BASH_COMPLETION)/bash_completion.d
+	rmdir $(CONFIG_DIR)/todo
 
 installdirs:
-	mkdir -p $(DESTDIR)$(bindir) \
-	         $(DESTDIR)$(sysconfdir)/todo \
-	         $(DESTDIR)$(datarootdir)/bash_completion.d
+	mkdir -p $(INSTALL_DIR) \
+	         $(CONFIG_DIR)/todo \
+	         $(BASH_COMPLETION)/bash_completion.d
 
 #
 # Testing

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,28 @@ INSTALL_DATA = $(INSTALL) -m 644
 
 prefix = /usr/local
 
+# ifdef check allows the user to pass custom dirs
+# as per the README
+
 # The directory to install todo.sh in.
-INSTALL_DIR = $(prefix)/bin
+ifdef INSTALL_DIR
+	bindir = $(INSTALL_DIR)
+else
+	bindir = $(prefix)/bin
+endif
 
 # The directory to install the config file in.
-CONFIG_DIR = $(prefix)/etc
+ifdef CONFIG_DIR
+	sysconfdir = $(CONFIG_DIR)
+else
+	sysconfdir = $(prefix)/etc
+endif
 
-BASH_COMPLETION = $(prefix)/share
+ifdef BASH_COMPLETION
+	datarootdir = $(BASH_COMPLETION)
+else
+	datarootdir = $(prefix)/share
+endif
 
 # Dynamically detect/generate version file as necessary
 # This file will define a variable called VERSION.
@@ -48,23 +63,23 @@ clean: test-pre-clean
 	rm VERSION-FILE
 
 install: installdirs
-	$(INSTALL_PROGRAM) todo.sh $(DESTDIR)$(INSTALL_DIR)/todo.sh
-	$(INSTALL_DATA) todo_completion $(DESTDIR)$(BASH_COMPLETION)/bash_completion.d/todo
-	[ -e $(DESTDIR)$(CONFIG_DIR)/todo/config ] || \
-	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > $(DESTDIR)$(CONFIG_DIR)/todo/config
+	$(INSTALL_PROGRAM) todo.sh $(DESTDIR)$(bindir)/todo.sh
+	$(INSTALL_DATA) todo_completion $(DESTDIR)$(datarootdir)/bash_completion.d/todo
+	[ -e $(DESTDIR)$(sysconfdir)/todo/config ] || \
+	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > $(DESTDIR)$(sysconfdir)/todo/config
 
 uninstall:
-	rm -f $(DESTDIR)$(INSTALL_DIR)/todo.sh
-	rm -f $(DESTDIR)$(BASH_COMPLETION)/bash_completion.d/todo
-	rm -f $(DESTDIR)$(CONFIG_DIR)/todo/config
+	rm -f $(DESTDIR)$(bindir)/todo.sh
+	rm -f $(DESTDIR)$(datarootdir)/bash_completion.d/todo
+	rm -f $(DESTDIR)$(sysconfdir)/todo/config
 
-	rmdir $(DESTDIR)$(BASH_COMPLETION)/bash_completion.d
-	rmdir $(DESTDIR)$(CONFIG_DIR)/todo
+	rmdir $(DESTDIR)$(datarootdir)/bash_completion.d
+	rmdir $(DESTDIR)$(sysconfdir)/todo
 
 installdirs:
-	mkdir -p $(DESTDIR)$(INSTALL_DIR) \
-	         $(DESTDIR)$(CONFIG_DIR)/todo \
-	         $(DESTDIR)$(BASH_COMPLETION)/bash_completion.d
+	mkdir -p $(DESTDIR)$(bindir) \
+	         $(DESTDIR)$(sysconfdir)/todo \
+	         $(DESTDIR)$(datarootdir)/bash_completion.d
 
 #
 # Testing

--- a/Makefile
+++ b/Makefile
@@ -48,23 +48,23 @@ clean: test-pre-clean
 	rm VERSION-FILE
 
 install: installdirs
-	$(INSTALL_PROGRAM) todo.sh $(INSTALL_DIR)/todo.sh
-	$(INSTALL_DATA) todo_completion $(BASH_COMPLETION)/bash_completion.d/todo
-	[ -e $(CONFIG_DIR)/todo/config ] || \
-	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > $(CONFIG_DIR)/todo/config
+	$(INSTALL_PROGRAM) todo.sh $(DESTDIR)$(INSTALL_DIR)/todo.sh
+	$(INSTALL_DATA) todo_completion $(DESTDIR)$(BASH_COMPLETION)/bash_completion.d/todo
+	[ -e $(DESTDIR)$(CONFIG_DIR)/todo/config ] || \
+	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > $(DESTDIR)$(CONFIG_DIR)/todo/config
 
 uninstall:
-	rm -f $(INSTALL_DIR)/todo.sh
-	rm -f $(BASH_COMPLETION)/bash_completion.d/todo
-	rm -f $(CONFIG_DIR)/todo/config
+	rm -f $(DESTDIR)$(INSTALL_DIR)/todo.sh
+	rm -f $(DESTDIR)$(BASH_COMPLETION)/bash_completion.d/todo
+	rm -f $(DESTDIR)$(CONFIG_DIR)/todo/config
 
-	rmdir $(BASH_COMPLETION)/bash_completion.d
-	rmdir $(CONFIG_DIR)/todo
+	rmdir $(DESTDIR)$(BASH_COMPLETION)/bash_completion.d
+	rmdir $(DESTDIR)$(CONFIG_DIR)/todo
 
 installdirs:
-	mkdir -p $(INSTALL_DIR) \
-	         $(CONFIG_DIR)/todo \
-	         $(BASH_COMPLETION)/bash_completion.d
+	mkdir -p $(DESTDIR)$(INSTALL_DIR) \
+	         $(DESTDIR)$(CONFIG_DIR)/todo \
+	         $(DESTDIR)$(BASH_COMPLETION)/bash_completion.d
 
 #
 # Testing

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make test
 - `BASH_COMPLETION`: PATH for autocompletion scripts (default to /etc/bash_completion.d)
 
 ```shell
-make install CONFIG_DIR=/etc INSTALL_DIR=/usr/bin BASH_COMPLETION_DIR=/usr/share/bash-completion/completions
+make install CONFIG_DIR=/etc INSTALL_DIR=/usr/bin BASH_COMPLETION=/usr/share/bash-completion/completions
 ```
 
 #### Arch Linux (AUR)


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests!
- [ ] Ensure the test suite passes.
- [ ] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [x] Include a human-readable description of what the pull request is trying to accomplish.
- [ ] Steps for the reviewer(s) on how they can manually QA the changes.
- [ ] Have a `fixes #XX` reference to the issue that this pull request fixes.



First time working with a Makefile but all I did was fix it so the instructions in the README actually work.  
`INSTALL_DIR, CONFIG_DIR & BASH_COMPLETION` were not used in the original Makefile, instead there were `bindir, sysconfdir & datarootdir`.  
Also removed all the references to `DESTDIR` because that was not used at all and did nothing.

The default install location is still the same as I've changed nothing besides naming.