### PR TITLE
Refactoring: Extract the many complex sed arguments into sedTransformations

### DIFF
--- a/todo_completion
+++ b/todo_completion
@@ -48,23 +48,28 @@ _todo()
                         completions=$(eval 'TODOTXT_VERBOSE=0 TODOTXT_SOURCEVAR=\$DONE_FILE' $_todo_sh command listcon 2>/dev/null)
                         ;;
                     *)  if [[ "$cur" =~ ^[0-9]+$ ]]; then
-                            # Remove the (padded) task number; we prepend the
-                            # user-provided $cur instead.
-                            # Remove the timestamp prepended by the -t option,
-                            # and the done date (for done tasks); there's no
-                            # todo.txt option for that yet.
-                            # But keep priority and "x"; they're short and may
-                            # provide useful context.
-                            # Remove any trailing whitespace; the Bash
-                            # completion inserts a trailing space itself.
-                            # Finally, limit the output to a single line just as
-                            # a safety check of the ls action output.
+                            declare -a sedTransformations=(
+                                # Remove the (padded) task number; we prepend the
+                                # user-provided $cur instead.
+                                -e 's/^ *[0-9]\{1,\} //'
+                                # Remove the timestamp prepended by the -t option,
+                                # but keep any priority (as it's short and may
+                                # provide useful context).
+                                -e 's/^\((.) \)\{0,1\}[0-9]\{2,4\}-[0-9]\{2\}-[0-9]\{2\} /\1/'
+                                # Remove the done date and (if there) the timestamp.
+                                # Keep the "x" (as it's short and may provide useful
+                                # context)
+                                -e 's/^\([xX] \)\([0-9]\{2,4\}-[0-9]\{2\}-[0-9]\{2\} \)\{1,2\}/\1/'
+                                # Remove any trailing whitespace; the Bash
+                                # completion inserts a trailing space itself.
+                                -e 's/[[:space:]]*$//'
+                                # Finally, limit the output to a single line just as
+                                # a safety check of the ls action output.
+                                -e '1q'
+                            )
                             local todo=$( \
                                 eval TODOTXT_VERBOSE=0 $_todo_sh '-@ -+ -p -x command ls "^ *${cur} "' 2>/dev/null | \
-                                sed -e 's/^ *[0-9]\{1,\} //' -e 's/^\((.) \)\{0,1\}[0-9]\{2,4\}-[0-9]\{2\}-[0-9]\{2\} /\1/' \
-                                    -e 's/^\([xX] \)\([0-9]\{2,4\}-[0-9]\{2\}-[0-9]\{2\} \)\{1,2\}/\1/' \
-                                    -e 's/[[:space:]]*$//' \
-                                    -e '1q' \
+                                sed "${sedTransformations[@]}" \
                             )
                             # Append task text as a shell comment. This
                             # completion can be a safety check before a


### PR DESCRIPTION
… and move the comments closer

There's too much distance between the comments that describe the various transformations that are done on the referenced task, and the corresponding sed expressions.
By using a local Bash array, we can collect the arguments and have the comments close by.

**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [X] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [ ] Format your code with [ShellCheck](https://www.shellcheck.net/). _The completion didn't pass beforehand, the patch doesn't change the situation._
- [ ] Include a human-readable description of what the pull request is trying to accomplish. _No change in functionality._
- [ ] Steps for the reviewer(s) on how they can manually QA the changes. _Automated tests exist._
- [ ] Have a `fixes #XX` reference to the issue that this pull request fixes. _No issue, just refactoring._
