### PR TITLE
Check for local/`$(pwd)` config file first

### DIFF
--- a/tests/t0000-config.sh
+++ b/tests/t0000-config.sh
@@ -37,7 +37,7 @@ EOF
 rm -f used_config
 test_expect_success 'config file ($PWD location)' '
     mkdir tmp
-    cp test.cfg tmp/todo.cfg
+    cp test.cfg tmp/todos.cfg
     cd tmp
     todo.sh > ../output;
     cd ..

--- a/tests/t0000-config.sh
+++ b/tests/t0000-config.sh
@@ -35,6 +35,17 @@ touch used_config
 EOF
 
 rm -f used_config
+test_expect_success 'config file ($PWD location)' '
+    mkdir tmp
+    cp test.cfg tmp/todo.cfg
+    cd tmp
+    todo.sh > ../output;
+    cd ..
+    test_cmp expect output && test -f tmp/used_config &&
+        rm -rf tmp
+'
+
+rm -f used_config
 test_expect_success 'config file (default location 1)' '
     mkdir .todo
     cp test.cfg .todo/config

--- a/tests/t2200-no-done-report-files.sh
+++ b/tests/t2200-no-done-report-files.sh
@@ -8,8 +8,6 @@ checks that no such empty files are created.
 '
 . ./test-lib.sh
 
-rm -f todo.cfg
-
 cat > test.cfg << EOF
 export TODO_DIR=.
 export TODO_FILE="\$TODO_DIR/todo.txt"

--- a/tests/t2200-no-done-report-files.sh
+++ b/tests/t2200-no-done-report-files.sh
@@ -8,6 +8,8 @@ checks that no such empty files are created.
 '
 . ./test-lib.sh
 
+rm -f todo.cfg
+
 cat > test.cfg << EOF
 export TODO_DIR=.
 export TODO_FILE="\$TODO_DIR/todo.txt"

--- a/todo.sh
+++ b/todo.sh
@@ -657,6 +657,12 @@ export COLOR_DONE=$LIGHT_GREY   # color for done (but not yet archived) tasks
 # (todo.sh add 42 ", foo") syntactically correct.
 export SENTENCE_DELIMITERS=',.:;'
 
+CFG_FILE_ALT=$(pwd)"/todo.cfg"
+
+[ -e "$CFG_FILE_ALT" ] && {
+    TODOTXT_CFG_FILE="$CFG_FILE_ALT"
+}
+
 [ -e "$TODOTXT_CFG_FILE" ] || {
     CFG_FILE_ALT="$HOME/todo.cfg"
 

--- a/todo.sh
+++ b/todo.sh
@@ -657,7 +657,7 @@ export COLOR_DONE=$LIGHT_GREY   # color for done (but not yet archived) tasks
 # (todo.sh add 42 ", foo") syntactically correct.
 export SENTENCE_DELIMITERS=',.:;'
 
-CFG_FILE_ALT=$(pwd)"/todo.cfg"
+CFG_FILE_ALT=$(pwd)"/todos.cfg"
 
 [ -e "$CFG_FILE_ALT" ] && {
     TODOTXT_CFG_FILE="$CFG_FILE_ALT"


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [x] If you've added code that should be tested, add tests!
- [x] Ensure the test suite passes.
- [x] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [x] Include a human-readable description of what the pull request is trying to accomplish.

Look up for `$(pwd)/todos.cfg` first.

Allows to use multiple `todo.txt` files more conveniently (transparent `-d` option...).

Not really happy with solution but I tried to have the least bug surface (because by using default `$(pwd)/todo.cfg` name I ran into many failed tests, and I don't think such a feature is worth rewriting the whole behavior).

But this is open for discussion. Bottom line being: It would be nice to look up some local config file first.
