### PR TITLE
s/GRAY/GREY/ in todo.cfg

### DIFF
--- a/todo.cfg
+++ b/todo.cfg
@@ -67,7 +67,7 @@ export REPORT_FILE="$TODO_DIR/report.txt"
 # export COLOR_PROJECT=$RED
 # export COLOR_CONTEXT=$RED
 # export COLOR_DATE=$BLUE
-# export COLOR_NUMBER=$LIGHT_GRAY
+# export COLOR_NUMBER=$LIGHT_GREY
 
 # There is highlighting for metadata key:value pairs e.g.
 # DUE:2006-08-01 or note:MYNOTE


### PR DESCRIPTION
`GREY` is the spelling used in every other place in this repository.
