### PR TITLE
Allow multiple priorities on single run fixes #281

### DIFF
--- a/tests/t1200-pri.sh
+++ b/tests/t1200-pri.sh
@@ -6,7 +6,7 @@ test_description='basic priority functionality
 
 test_todo_session 'priority usage' <<EOF
 >>> todo.sh pri B B
-usage: todo.sh pri ITEM# PRIORITY
+usage: todo.sh pri ITEM# PRIORITY[, ITEM# PRIORITY, ...]
 note: PRIORITY must be anywhere from A to Z.
 === 1
 EOF
@@ -99,5 +99,40 @@ TODO: 2 already prioritized (A).
 3 stop
 --
 TODO: 3 of 3 tasks shown
+EOF
+
+cat > todo.txt <<EOF
+smell the uppercase Roses +flowers @outside
+notice the sunflowers
+stop
+EOF
+test_todo_session 'multiple priority' <<EOF
+>>> todo.sh pri 1 A 2 B
+1 (A) smell the uppercase Roses +flowers @outside
+TODO: 1 prioritized (A).
+2 (B) notice the sunflowers
+TODO: 2 prioritized (B).
+EOF
+
+test_todo_session 'multiple reprioritize' <<EOF
+>>> todo.sh pri 1 Z 2 X
+1 (Z) smell the uppercase Roses +flowers @outside
+TODO: 1 re-prioritized from (A) to (Z).
+2 (X) notice the sunflowers
+TODO: 2 re-prioritized from (B) to (X).
+EOF
+
+test_todo_session 'multiple prioritize error' <<EOF
+>>> todo.sh pri 1 B 4 B
+=== 1
+1 (B) smell the uppercase Roses +flowers @outside
+TODO: 1 re-prioritized from (Z) to (B).
+TODO: No task 4.
+
+>>> todo.sh pri 1 C 4 B 3 A
+=== 1
+1 (C) smell the uppercase Roses +flowers @outside
+TODO: 1 re-prioritized from (B) to (C).
+TODO: No task 4.
 EOF
 test_done

--- a/todo.sh
+++ b/todo.sh
@@ -62,7 +62,7 @@ shorthelp()
 		    listproj|lsprj [TERM...]
 		    move|mv ITEM# DEST [SRC]
 		    prepend|prep ITEM# "TEXT TO PREPEND"
-		    pri|p ITEM# PRIORITY
+		    pri|p ITEM# PRIORITY[, ITEM# PRIORITY, ...]
 		    replace ITEM# "UPDATED TODO"
 		    report
 		    shorthelp
@@ -1405,38 +1405,42 @@ case $action in
     ;;
 
 "pri" | "p" )
-    item=$2
-    newpri=$( printf "%s\n" "$3" | tr '[:lower:]' '[:upper:]' )
+    shift
+    while [ "$#" -gt 0 ] ; do
+        item=$1
+        newpri=$( printf "%s\n" "$2" | tr '[:lower:]' '[:upper:]' )
 
-    errmsg="usage: $TODO_SH pri ITEM# PRIORITY
+        errmsg="usage: $TODO_SH pri ITEM# PRIORITY[, ITEM# PRIORITY, ...]
 note: PRIORITY must be anywhere from A to Z."
 
-    [ "$#" -ne 3 ] && die "$errmsg"
-    [[ "$newpri" = @([A-Z]) ]] || die "$errmsg"
-    getTodo "$item"
+        [ "$#" -lt 2 ] && die "$errmsg"
+        [[ "$newpri" = @([A-Z]) ]] || die "$errmsg"
+        getTodo "$item"
 
-    oldpri=
-    if [[ "$todo" = \(?\)\ * ]]; then
-        oldpri=${todo:1:1}
-    fi
+        oldpri=
+        if [[ "$todo" = \(?\)\ * ]]; then
+            oldpri=${todo:1:1}
+        fi
 
-    if [ "$oldpri" != "$newpri" ]; then
-        sed -i.bak -e "${item}s/^(.) //" -e "${item}s/^/($newpri) /" "$TODO_FILE"
-    fi
-    if [ "$TODOTXT_VERBOSE" -gt 0 ]; then
-        getNewtodo "$item"
-        echo "$item $newtodo"
         if [ "$oldpri" != "$newpri" ]; then
-            if [ "$oldpri" ]; then
-                echo "TODO: $item re-prioritized from ($oldpri) to ($newpri)."
-            else
-                echo "TODO: $item prioritized ($newpri)."
+            sed -i.bak -e "${item}s/^(.) //" -e "${item}s/^/($newpri) /" "$TODO_FILE"
+        fi
+        if [ "$TODOTXT_VERBOSE" -gt 0 ]; then
+            getNewtodo "$item"
+            echo "$item $newtodo"
+            if [ "$oldpri" != "$newpri" ]; then
+                if [ "$oldpri" ]; then
+                    echo "TODO: $item re-prioritized from ($oldpri) to ($newpri)."
+                else
+                    echo "TODO: $item prioritized ($newpri)."
+                fi
             fi
         fi
-    fi
-    if [ "$oldpri" = "$newpri" ]; then
-        echo "TODO: $item already prioritized ($newpri)."
-    fi
+        if [ "$oldpri" = "$newpri" ]; then
+            echo "TODO: $item already prioritized ($newpri)."
+        fi
+    shift; shift
+    done
     ;;
 
 "replace" )


### PR DESCRIPTION
Uses current priority logic and option tests just running multiple times until item and priority pairs are exhausted or stops on first error.

Tests for multiple priorities, multiple re-prioritisations and a couple of errors created. All tests pass.

fixes #281

Usage is: todo.sh pri 1 A 2 B 3 C
which changes priority on lines 1, 2 and 3.