### PR TITLE
TESTSFIX: t0000-config.sh may unintentionally pick up existing user config in $XDG_CONFIG_HOME/todo/config

### DIFF
--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -693,6 +693,8 @@ cd -P "$test" || exit 1
 # but use something specified by the framework.
 HOME=$(pwd)
 export HOME
+# Unset XDG_CONFIG_HOME as that is used as a config alternative.
+unset XDG_CONFIG_HOME
 
 this_test=${0##*/}
 this_test=${this_test%%-*}

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -695,6 +695,11 @@ HOME=$(pwd)
 export HOME
 # Unset XDG_CONFIG_HOME as that is used as a config alternative.
 unset XDG_CONFIG_HOME
+# User add-ons may override built-in commands; these could have incompatible
+# behavior that makes the tests fail. Avoid picking up user add-ons by
+# explicitly configuring the first default location (which with the redirected
+# HOME lies within the test directory and usually does not exist).
+export TODO_ACTIONS_DIR="$HOME/.todo/actions"
 
 this_test=${0##*/}
 this_test=${this_test%%-*}


### PR DESCRIPTION
This corner case was missed when the XDG alternative config location was introduced, likely because the variable isn't set by default on Ubuntu or Mac OS, and none of the developers had a config there.
`HOME` is already redirected to the current working directory; as `XDG_CONFIG_HOME` is just a config alternative that has a fallback to `$HOME/.config`, simply unset it.

Fixes #347

**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes.
- [X] Have a `fixes #XX` reference to the issue that this pull request fixes.