### PR TITLE
Fix issue #361 - add persistence for priority on completion, as an option defaulting to original behavior

### DIFF
--- a/tests/t0000-config.sh
+++ b/tests/t0000-config.sh
@@ -21,7 +21,7 @@ test_expect_success 'no config file' '
 
 # All the below tests will output the usage message.
 cat > expect <<EOF
-Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
 Try 'todo.sh -h' for more information.
 EOF
 

--- a/tests/t2100-help.sh
+++ b/tests/t2100-help.sh
@@ -11,21 +11,21 @@ This test covers the help output.
 # slightly changes, only check for the section headers.
 test_todo_session 'help output' <<EOF
 >>> todo.sh help | sed '/^  [A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Options:
   Built-in Actions:
 EOF
 
 test_todo_session 'verbose help output' <<EOF
 >>> todo.sh -v help | sed '/^  [A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Options:
   Built-in Actions:
 EOF
 
 test_todo_session 'very verbose help output' <<EOF
 >>> todo.sh -vv help | sed '/^  [A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Options:
   Environment variables:
   Built-in Actions:
@@ -34,7 +34,7 @@ EOF
 make_action "foo"
 test_todo_session 'help output with custom action' <<EOF
 >>> todo.sh -v help | sed '/^  [A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Options:
   Built-in Actions:
   Add-on Actions:

--- a/tests/t2120-shorthelp.sh
+++ b/tests/t2120-shorthelp.sh
@@ -11,7 +11,7 @@ This test covers the output of the -h option and the shorthelp action.
 # check for the section headers.
 test_todo_session '-h output' <<EOF
 >>> todo.sh -h | sed '/^  [A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Actions:
   Actions can be added and overridden using scripts in the actions
   See "help" for more details.
@@ -19,7 +19,7 @@ EOF
 
 test_todo_session 'shorthelp output' <<EOF
 >>> todo.sh shorthelp | sed '/^  [A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Actions:
   Actions can be added and overridden using scripts in the actions
   See "help" for more details.
@@ -28,7 +28,7 @@ EOF
 make_action "foo"
 test_todo_session 'shorthelp output with custom action' <<EOF
 >>> todo.sh -v shorthelp | sed '/^  [A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Actions:
   Actions can be added and overridden using scripts in the actions
   Add-on Actions:
@@ -48,7 +48,7 @@ export TODOTXT_GLOBAL_CFG_FILE=global.cfg
 
 test_todo_session '-h and fatal error without config' <<EOF
 >>> todo.sh -h | sed '/^ \\{0,2\\}[A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Actions:
   Actions can be added and overridden using scripts in the actions
   See "help" for more details.
@@ -59,7 +59,7 @@ EOF
 # Config option comes too late; "Add-on Actions" is *not* mentioned here.
 test_todo_session '-h and fatal error with trailing custom config' <<EOF
 >>> todo.sh -h -d custom.cfg | sed '/^ \\{0,2\\}[A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Actions:
   Actions can be added and overridden using scripts in the actions
   See "help" for more details.
@@ -70,7 +70,7 @@ EOF
 # Config option processed; "Add-on Actions" is mentioned here.
 test_todo_session '-h output with preceding custom config' <<EOF
 >>> todo.sh -d custom.cfg -h | sed '/^ \\{0,2\\}[A-Z]/!d'
-  Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+  Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
   Actions:
   Actions can be added and overridden using scripts in the actions
   Add-on Actions:

--- a/tests/t6000-completion.sh
+++ b/tests/t6000-completion.sh
@@ -7,7 +7,7 @@ This test checks basic todo_completion of actions and options
 . ./test-lib.sh
 
 readonly ACTIONS='add a addto addm append app archive command del rm depri dp do help list ls listaddons listall lsa listcon lsc listfile lf listpri lsp listproj lsprj move mv prepend prep pri p replace report shorthelp'
-readonly OPTIONS='-@ -@@ -+ -++ -d -f -h -p -P -PP -a -n -t -v -vv -V -x'
+readonly OPTIONS='-@ -@@ -+ -++ -d -f -h -p -P -PP -a -m -n -t -v -vv -V -x'
 
 test_todo_completion 'all arguments' 'todo.sh ' "$ACTIONS $OPTIONS"
 test_todo_completion 'arguments beginning with a' 'todo.sh a' 'add a addto addm append app archive'

--- a/tests/t6050-completion-addons.sh
+++ b/tests/t6050-completion-addons.sh
@@ -7,7 +7,7 @@ This test checks todo_completion of custom actions in .todo.actions.d
 . ./test-lib.sh
 
 readonly ACTIONS='add a addto addm append app archive command del rm depri dp do help list ls listaddons listall lsa listcon lsc listfile lf listpri lsp listproj lsprj move mv prepend prep pri p replace report shorthelp'
-readonly OPTIONS='-@ -@@ -+ -++ -d -f -h -p -P -PP -a -n -t -v -vv -V -x'
+readonly OPTIONS='-@ -@@ -+ -++ -d -f -h -p -P -PP -a -m -n -t -v -vv -V -x'
 
 readonly ADDONS='bar baz foobar'
 

--- a/tests/t8000-actions.sh
+++ b/tests/t8000-actions.sh
@@ -21,7 +21,7 @@ if [ -x .todo.actions.d/foo ]; then
 fi
 test_todo_session 'nonexecutable action' <<EOF
 >>> todo.sh foo
-Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
 Try 'todo.sh -h' for more information.
 === 1
 EOF

--- a/tests/t9999-testsuite_example.sh
+++ b/tests/t9999-testsuite_example.sh
@@ -159,7 +159,7 @@ TODO: 6 of 6 tasks shown
 TODO: 6 of 6 tasks shown
 
 >>> todo.sh remdup
-Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_description]
+Usage: todo.sh [-fhpamntvV] [-d todo_config] action [task_number] [task_description]
 Try 'todo.sh -h' for more information.
 === 1
 EOF

--- a/todo_completion
+++ b/todo_completion
@@ -10,7 +10,7 @@ _todo()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    local -r OPTS="-@ -@@ -+ -++ -d -f -h -p -P -PP -a -n -t -v -vv -V -x"
+    local -r OPTS="-@ -@@ -+ -++ -d -f -h -p -P -PP -a -m -n -t -v -vv -V -x"
     local -r COMMANDS="\
         add a addto addm append app archive command del  \
         rm depri dp do help list ls listaddons listall lsa listcon  \


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [x] If you've added code that should be tested, add tests!
- [x] Ensure the test suite passes.
- [x] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [x] Include a human-readable description of what the pull request is trying to accomplish.
- [x] Steps for the reviewer(s) on how they can manually QA the changes.
- [x] Have a `fixes #XX` reference to the issue that this pull request fixes.

Reviewer, manual QA of change:
Setup:
```
todo.sh add "(A) my task loses priority"
todo.sh add "(A) my task keeps priority"
```

Testing:
Verify no change in existing functionality:
Run:
```
@$ todo.sh do 1
1 x 2021-09-19 my task loses priority
TODO: 1 marked as done.
```
Verify that the Priority is removed, as is the currently expected behavior:
```
@$ todo.sh list
2 (A) my task keeps priority
1 x 2021-09-19 my task loses priority
--
TODO: 2 of 2 tasks shown
```


Verify that the new feature works (allow persistence of priority after completion, if user specifies `-m`):
Run:
```
@$ todo.sh -m do 2
2 x 2021-09-19 (A) my task keeps priority
TODO: 2 marked as done.
```
Verify that the Priority persists after the completion:
```
@$ todo.sh list
2 x 2021-09-19 (A) my task keeps priority
1 x 2021-09-19 my task loses priority
--
TODO: 2 of 2 tasks shown
```
