### PR TITLE
Add TODOTXT_VERBOSE to the configuration

### DIFF
--- a/todo.cfg
+++ b/todo.cfg
@@ -76,6 +76,13 @@ export REPORT_FILE="$TODO_DIR/report.txt"
 
 # === BEHAVIOR ===
 
+## verbosity
+#
+# By default, additional information and confirmation of actions (like
+# "TODO: 1 added") are printed. You can suppress this via 0 or add extra
+# verbosity via 2.
+# export TODOTXT_VERBOSE=1
+
 ## customize list output
 #
 # TODOTXT_SORT_COMMAND will filter after line numbers are


### PR DESCRIPTION
There's no command-line option to reduce verbosity (just `-v` to increase it), so users who would like to remove the additional messages (cp. https://github.com/todotxt/todo.txt-cli/discussions/364) have to configure this, but the variable is hard to find.
Include the default value in commented-out form and some documentation of the possible values.

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [ ] Steps for the reviewer(s) on how they can manually QA the changes.
- [ ] Have a `fixes #XX` reference to the issue that this pull request fixes.
