### PR TITLE
README.md: replace hardcoded path to command substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,7 @@ Download the latest stable [release][release] for use on your desktop or server.
 ```shell
 brew install todo-txt
 
-# For macOS on x86 CPU 
-cp -n /usr/local/opt/todo-txt/todo.cfg ~/.todo.cfg
-
-# For macOS on arm CPU
-cp -n /opt/homebrew/opt/todo-txt/todo.cfg ~/.todo.cfg
+cp -n $(brew --prefix)/opt/todo-txt/todo.cfg ~/.todo.cfg
 ```
 
 **Note**: The `-n` flag for `cp` makes sure you do not overwrite an existing file.


### PR DESCRIPTION
This patch replaces hardcoded path in README.md. Since Homebrew (or Linuxbrew) can be installed anywhere on user's system, use of hard-coded path should be avoided.

Signed-off-by: KOSHIKAWA Kenichi <reishoku.misc ~~at~~ pm.me>

----------------------------

**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [x] If you've added code that should be tested, add tests!
- [x] Ensure the test suite passes.
- [x] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [x] Include a human-readable description of what the pull request is trying to accomplish.
- [x] Steps for the reviewer(s) on how they can manually QA the changes.
- [x] Have a `fixes #XX` reference to the issue that this pull request fixes.
