### PR TITLE
Refactoring: Replace shellquote() with printf %q

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -824,11 +824,6 @@ _addto() {
     fi
 }
 
-shellquote()
-{
-    typeset -r qq=\'; printf %s\\n "'${1//\'/${qq}\\${qq}${qq}}'";
-}
-
 filtercommand()
 {
     filter=${1:-}
@@ -843,13 +838,13 @@ filtercommand()
         then
             ## First character isn't a dash: hide lines that don't match
             ## this $search_term
-            filter="${filter:-}${filter:+ | }grep -i $(shellquote "$search_term")"
+            printf -v filter '%sgrep -i %q' "${filter:-}${filter:+ | }" "$search_term"
         else
             ## First character is a dash: hide lines that match this
             ## $search_term
             #
             ## Remove the first character (-) before adding to our filter command
-            filter="${filter:-}${filter:+ | }grep -v -i $(shellquote "${search_term:1}")"
+            printf -v filter '%sgrep -v -i %q' "${filter:-}${filter:+ | }" "${search_term:1}"
         fi
     done
 
@@ -1036,7 +1031,7 @@ listWordsWithSigil()
 		| sort -u
 }
 
-export -f cleaninput getPrefix getTodo getNewtodo shellquote filtercommand _list listWordsWithSigil getPadding _format die
+export -f cleaninput getPrefix getTodo getNewtodo filtercommand _list listWordsWithSigil getPadding _format die
 
 # == HANDLE ACTION ==
 action=$( printf "%s\n" "$ACTION" | tr '[:upper:]' '[:lower:]' )


### PR DESCRIPTION
I didn't know about printf's capability when I introduced quoting 10 years ago. The `%q` format will do the quoting, and `-v VAR` can be used to reassign to the variable.

Note: The shellquote() function has been exported for reuse by add-ons. I don't think anyone has ever used that (it was mostly intended for my own, extensive extensions, and I never used it), and is trivial to move away from, anyway.


- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes.
- [ ] Have a `fixes #XX` reference to the issue that this pull request fixes.