### PR TITLE
Renaming: Add .sh extension to completion script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ clean: test-pre-clean
 
 install: installdirs
 	$(INSTALL_PROGRAM) todo.sh $(DESTDIR)$(bindir)/todo.sh
-	$(INSTALL_DATA) todo_completion $(DESTDIR)$(datarootdir)/todo
+	$(INSTALL_DATA) todo_completion $(DESTDIR)$(datarootdir)/todo.sh
 	[ -e $(DESTDIR)$(sysconfdir)/todo/config ] || \
 	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" todo.cfg > $(DESTDIR)$(sysconfdir)/todo/config
 


### PR DESCRIPTION
This doesn't matter if (as currently recommended) the script is placed into a eagerly loaded location (like `/etc/bash_completion.d/`) - any name will do.
However, there's now lazy loading of completion scripts (in `/usr/share/bash-completion/completions/`), and that only works when the completion script is named exactly like the command the completion is for. As our command is `todo.sh` (ignoring aliases, which become more complex with lazy loading), the corresponding completion needs to be `todo.sh` (with the `.sh` extension) as well. Renaming does not do any harm for our recommended location, but makes it easier for users (and packagers who prepare a todo.sh package) that want to use lazy loading.

See #383 for the complete discussion.


**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [ ] Steps for the reviewer(s) on how they can manually QA the changes.
- [ ] Have a `fixes #XX` reference to the issue that this pull request fixes.