### PR TITLE
todo.sh replace using STDIN: remove priority prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/trash\ directory.*
 done.txt
 report.txt
 todo.txt
+.vscode

--- a/tests/t1100-replace.sh
+++ b/tests/t1100-replace.sh
@@ -172,4 +172,11 @@ TODO: Replaced task with:
 1 (B) 2010-07-04 this also has a new date
 EOF
 
+echo '(A) 2022-06-16 replace me using stdin' > todo.txt
+test_todo_session 'replace with prepended priority using stdin' <<EOF
+>>> todo.sh replace 1 <<< "(A) 2022-06-16 the text is now replaced"
+TODO: Replaced task with:
+1 (A) 2022-06-16 the text is now replaced
+EOF
+
 test_done

--- a/tests/t1100-replace.sh
+++ b/tests/t1100-replace.sh
@@ -172,11 +172,4 @@ TODO: Replaced task with:
 1 (B) 2010-07-04 this also has a new date
 EOF
 
-echo '(A) 2022-06-16 replace me using stdin' > todo.txt
-test_todo_session 'replace with prepended priority using stdin' <<EOF
->>> todo.sh replace 1 <<< "(A) 2022-06-16 the text is now replaced"
-TODO: Replaced task with:
-1 (A) 2022-06-16 the text is now replaced
-EOF
-
 test_done

--- a/tests/t8010-listaddons.sh
+++ b/tests/t8010-listaddons.sh
@@ -33,6 +33,8 @@ chmod -x .todo.actions.d/foo
 # may still grant execution rights. In this case, we skip the test.
 if [ -x .todo.actions.d/foo ]; then
     SKIP_TESTS="${SKIP_TESTS}${SKIP_TESTS+ }t8010.4"
+    # foo is effectively ignored so just straight out delete it.
+    rm .todo.actions.d/foo
 fi
 test_todo_session 'nonexecutable action' <<EOF
 >>> todo.sh listaddons
@@ -72,6 +74,7 @@ chmod -x .todo.actions.d/norris/norris
 # may still grant execution rights. In this case, we skip the test.
 if [ -x .todo.actions.d/norris/norris ]; then
     SKIP_TESTS="${SKIP_TESTS}${SKIP_TESTS+ }t8010.8"
+    rm .todo.actions.d/norris/norris
 fi
 test_todo_session 'nonexecutable action in subfolder' <<EOF
 >>> todo.sh listaddons

--- a/todo.sh
+++ b/todo.sh
@@ -452,7 +452,8 @@ replaceOrPrepend()
 
   if [[ -z "$1" && $TODOTXT_FORCE = 0 ]]; then
     echo -n "$querytext"
-    read -r -i "$todo" -e input
+    todo_removed_prio=$(echo $todo | sed -e "s/([A-Z]) *//g")
+    read -r -i "$todo_removed_prio" -e input
   else
     input=$*
   fi


### PR DESCRIPTION
# Changes

- Remove the priority prefix when `todo.sh replace <ID>` with stdin input
- Add Cygwin little fix for `t8010-listaddons.sh`
  - Remove the actions that are supposedly skipped before executing the next tests

# Previously

The portion surrounded by `{}` is the initial input provided

```console
$ ./todo.sh add "(A) new task"
$ ./todo.sh replace 1
Replacement: {(A) new task}
1 (A) new task
TDOO: Replaced task with:
1 (A) (A) new task
```

# After

```console
$ ./todo.sh add "(A) new task"
$ ./todo.sh replace 1
Replacement: {new task}
1 (A) new task
TODO: Replaced task with:
1 (A) new task
```

**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [x] If you've added code that should be tested, add tests!
- [x] Ensure the test suite passes.
- [x] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [x] Include a human-readable description of what the pull request is trying to accomplish.
- [x] Steps for the reviewer(s) on how they can manually QA the changes.
- [x] Have a `fixes #XX` reference to the issue that this pull request fixes.
