### PR TITLE
TESTSFIX: t8010-listaddons breaks on Cygwin

### DIFF
--- a/tests/actions-test-lib.sh
+++ b/tests/actions-test-lib.sh
@@ -34,3 +34,19 @@ echo "custom action $1 in folder $1"
 EOF
 chmod +x ".todo.actions.d/$1/$1"
 }
+
+invalidate_action()
+{
+    local customActionFilespec="${1:?}"; shift
+    local testName="${1:?}"; shift
+
+    chmod -x "$customActionFilespec"
+    # On Cygwin, clearing the executable flag may have no effect, as the Windows
+    # ACL may still grant execution rights. In this case, we skip the test, and
+    # remove the (still valid) custom action so that it doesn't break following
+    # tests.
+    if [ -x "$customActionFilespec" ]; then
+        SKIP_TESTS="${SKIP_TESTS}${SKIP_TESTS+ }${testName}"
+        rm -- "$customActionFilespec"
+    fi
+}

--- a/tests/t8010-listaddons.sh
+++ b/tests/t8010-listaddons.sh
@@ -30,9 +30,11 @@ EOF
 
 chmod -x .todo.actions.d/foo
 # On Cygwin, clearing the executable flag may have no effect, as the Windows ACL
-# may still grant execution rights. In this case, we skip the test.
+# may still grant execution rights. In this case, we skip the test, and remove
+# the (still valid) custom action so that it doesn't break following tests.
 if [ -x .todo.actions.d/foo ]; then
     SKIP_TESTS="${SKIP_TESTS}${SKIP_TESTS+ }t8010.4"
+    rm .todo.actions.d/foo
 fi
 test_todo_session 'nonexecutable action' <<EOF
 >>> todo.sh listaddons
@@ -69,9 +71,11 @@ EOF
 # nthorne: shamelessly stolen from above..
 chmod -x .todo.actions.d/norris/norris
 # On Cygwin, clearing the executable flag may have no effect, as the Windows ACL
-# may still grant execution rights. In this case, we skip the test.
+# may still grant execution rights. In this case, we skip the test, and remove
+# the (still valid) custom action so that it doesn't break following tests.
 if [ -x .todo.actions.d/norris/norris ]; then
     SKIP_TESTS="${SKIP_TESTS}${SKIP_TESTS+ }t8010.8"
+    rm .todo.actions.d/norris/norris
 fi
 test_todo_session 'nonexecutable action in subfolder' <<EOF
 >>> todo.sh listaddons

--- a/tests/t8010-listaddons.sh
+++ b/tests/t8010-listaddons.sh
@@ -28,14 +28,7 @@ ls
 quux
 EOF
 
-chmod -x .todo.actions.d/foo
-# On Cygwin, clearing the executable flag may have no effect, as the Windows ACL
-# may still grant execution rights. In this case, we skip the test, and remove
-# the (still valid) custom action so that it doesn't break following tests.
-if [ -x .todo.actions.d/foo ]; then
-    SKIP_TESTS="${SKIP_TESTS}${SKIP_TESTS+ }t8010.4"
-    rm .todo.actions.d/foo
-fi
+invalidate_action .todo.actions.d/foo t8010.4
 test_todo_session 'nonexecutable action' <<EOF
 >>> todo.sh listaddons
 bar
@@ -68,15 +61,7 @@ norris
 quux
 EOF
 
-# nthorne: shamelessly stolen from above..
-chmod -x .todo.actions.d/norris/norris
-# On Cygwin, clearing the executable flag may have no effect, as the Windows ACL
-# may still grant execution rights. In this case, we skip the test, and remove
-# the (still valid) custom action so that it doesn't break following tests.
-if [ -x .todo.actions.d/norris/norris ]; then
-    SKIP_TESTS="${SKIP_TESTS}${SKIP_TESTS+ }t8010.8"
-    rm .todo.actions.d/norris/norris
-fi
+invalidate_action .todo.actions.d/norris/norris t8010.8
 test_todo_session 'nonexecutable action in subfolder' <<EOF
 >>> todo.sh listaddons
 bar


### PR DESCRIPTION
As the (still executable) custom action is still picked up by following tests. That was missed when later tests were added (because we don't have test automation on Cygwin).

**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [X] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes.
- [ ] Have a `fixes #XX` reference to the issue that this pull request fixes.