### PR TITLE
Simplifying mac installation instructions with HOMEBREW_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,7 @@ Download the latest stable [release][release] for use on your desktop or server.
 ```shell
 brew install todo-txt
 
-# For macOS on x86 CPU 
-cp -n /usr/local/opt/todo-txt/todo.cfg ~/.todo.cfg
-
-# For macOS on arm CPU
-cp -n /opt/homebrew/opt/todo-txt/todo.cfg ~/.todo.cfg
+cp -n $HOMEBREW_PREFIX/opt/todo-txt/todo.cfg ~/.todo.cfg
 ```
 
 **Note**: The `-n` flag for `cp` makes sure you do not overwrite an existing file.


### PR DESCRIPTION
Uses the `$HOMEBREW_PREFIX` environment variable rather than the absolute paths. This abstracts away from using the explicit path and works for most custom homebrew installations on MacOS

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from master.
- [x] If you've added code that should be tested, add tests! (NA)
- [ ] Ensure the test suite passes.
- [x] Format your code with [ShellCheck](https://www.shellcheck.net/). (NA)
- [x] Include a human-readable description of what the pull request is trying to accomplish.
- [x] Steps for the reviewer(s) on how they can manually QA the changes.
- [ ] Have a fixes #XX reference to the issue that this pull request fixes.