### PR TITLE
Added warning message for todo.sh archive

### DIFF
--- a/tests/t1900-archive.sh
+++ b/tests/t1900-archive.sh
@@ -32,4 +32,9 @@ test_todo_session 'list after archive' <<EOF
 TODO: 5 of 5 tasks shown
 EOF
 
+test_todo_session 'archive warning message' <<EOF
+>>> todo.sh archive
+TODO: $HOME/todo.txt does not contain any done tasks.
+EOF
+
 test_done

--- a/tests/t1950-report.sh
+++ b/tests/t1950-report.sh
@@ -16,7 +16,7 @@ EOF
 
 test_todo_session 'create new report' <<EOF
 >>> todo.sh report
-TODO: $HOME/todo.txt archived.
+TODO: $HOME/todo.txt does not contain any done tasks.
 2009-02-13T04:40:00 5 0
 TODO: Report file updated.
 
@@ -38,7 +38,7 @@ x 2009-02-13 smell the coffee +wakeup
 TODO: $HOME/todo.txt archived.
 
 >>> todo.sh report
-TODO: $HOME/todo.txt archived.
+TODO: $HOME/todo.txt does not contain any done tasks.
 2009-02-13T04:40:00 4 1
 TODO: Report file updated.
 
@@ -83,7 +83,7 @@ test_todo_session 'report is unchanged when no changes' <<EOF
 2009-02-13T04:40:00 3 2
 
 >>> todo.sh report
-TODO: $HOME/todo.txt archived.
+TODO: $HOME/todo.txt does not contain any done tasks.
 2009-02-13T04:40:00 3 2
 TODO: Report file is up-to-date.
 

--- a/tests/t2200-no-done-report-files.sh
+++ b/tests/t2200-no-done-report-files.sh
@@ -38,7 +38,7 @@ test_expect_success 'no done file has been created by the archiving' '[ ! -e don
 
 test_todo_session 'perform report' <<EOF
 >>> todo.sh -d test.cfg report
-TODO: ./todo.txt archived.
+TODO: ./todo.txt does not contain any done tasks.
 2009-02-13T04:40:00 0 0
 TODO: Report file updated.
 EOF

--- a/tests/t9999-testsuite_example.sh
+++ b/tests/t9999-testsuite_example.sh
@@ -85,7 +85,7 @@ TODO: $HOME/todo.txt archived.
 TODO: 5 of 5 tasks shown
 
 >>> todo.sh report
-TODO: $HOME/todo.txt archived.
+TODO: $HOME/todo.txt does not contain any done tasks.
 2009-02-13T04:40:00 5 1
 TODO: Report file updated.
 

--- a/todo.sh
+++ b/todo.sh
@@ -1142,8 +1142,8 @@ case $action in
 "archive" )
     # defragment blank lines
     sed -i.bak -e '/./!d' "$TODO_FILE"
-    if grep "^x " "$TODO_FILE"; then
-        grep "^x " "$TODO_FILE" >> "$DONE_FILE"
+    if grep "^x " "$TODO_FILE" >> "$DONE_FILE"; then
+	[ "$TODOTXT_VERBOSE" -gt 0 ] && grep "^x " "$TODO_FILE"   
         sed -i.bak '/^x /d' "$TODO_FILE"
         if [ "$TODOTXT_VERBOSE" -gt 0 ]; then
             echo "TODO: $TODO_FILE archived."

--- a/todo.sh
+++ b/todo.sh
@@ -1142,11 +1142,16 @@ case $action in
 "archive" )
     # defragment blank lines
     sed -i.bak -e '/./!d' "$TODO_FILE"
-    [ "$TODOTXT_VERBOSE" -gt 0 ] && grep "^x " "$TODO_FILE"
-    grep "^x " "$TODO_FILE" >> "$DONE_FILE"
-    sed -i.bak '/^x /d' "$TODO_FILE"
-    if [ "$TODOTXT_VERBOSE" -gt 0 ]; then
-        echo "TODO: $TODO_FILE archived."
+    if grep "^x " "$TODO_FILE"; then
+        grep "^x " "$TODO_FILE" >> "$DONE_FILE"
+        sed -i.bak '/^x /d' "$TODO_FILE"
+        if [ "$TODOTXT_VERBOSE" -gt 0 ]; then
+            echo "TODO: $TODO_FILE archived."
+        fi
+    else
+	if [ "$TODOTXT_VERBOSE" -gt 0 ]; then
+       	    echo "TODO: $TODO_FILE does not contain any done tasks."
+	fi
     fi
     ;;
 


### PR DESCRIPTION
I have added a warning message which `todo.sh archive` will print out if it does not find done tasks in the todo file. 
Before, it would even then print `TODO: ./todo.txt archived`.

**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [x] If you've added code that should be tested, add tests!
- [x] Ensure the test suite passes.
- [x] Format your code with [ShellCheck](https://www.shellcheck.net/).
- [x] Include a human-readable description of what the pull request is trying to accomplish.
- [ ] Steps for the reviewer(s) on how they can manually QA the changes.
- [ ] Have a `fixes #XX` reference to the issue that this pull request fixes.
