### PR TITLE
fix: Improve GNU sed fallback

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -26,6 +26,24 @@ export TODO_SH TODO_FULL_SH
 
 oneline_usage="$TODO_SH [-fhpantvV] [-d todo_config] action [task_number] [task_description]"
 
+# Assumption: The in-place argument is the first
+# Assumption: Only a single file is processed with sed
+sed() {
+    if command -v gsed &>/dev/null; then
+        gsed "$@"
+    elif [ "$1" = '-i.bak' ]; then
+        if ! shift; then
+            die "Failed to shift"
+        fi
+
+        filepath=${!#}
+        filepath_temp=/tmp/todo.sh-sed.$RANDOM.$$
+        command sed "$@" > "$filepath_temp" && mv "$filepath_temp" "$filepath"
+    else
+        command sed "$@"
+    fi
+}
+
 usage()
 {
     cat <<-EndUsage


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [x] If you've added code that should be tested, add tests!
- [x] Ensure the test suite passes.
- [x] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [x] Include a human-readable description of what the pull request is trying to accomplish.
- [x] Steps for the reviewer(s) on how they can manually QA the changes.
- [x] Have a `fixes #XX` reference to the issue that this pull request fixes.

Code inspired by [this comment](https://github.com/todotxt/todo.txt-cli/issues/168#issuecomment-392349995), this PR fixes the sed command on BSD/Busybox, etc. platforms in which GNU sed is not used.

Unlike what some comments in the linked issue suggests, the approach of exporting the function so todotxt add-ons can automatically use the fix was not done. This is because that would be a breaking change and there is no way we can guarantee that the assumptions of this `sed()` function hold true for all plugin code.

How to test:

```sh
make test
```

Closes #168