### PR TITLE
Improved Makefile.

### DIFF
--- a/GEN-VERSION-FILE
+++ b/GEN-VERSION-FILE
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Based on git's GIT-VERSION-GEN.
 
 VF=VERSION-FILE
@@ -7,7 +7,7 @@ DEF_VER=v0.0
 if test -d .git -o -f .git &&
 	VN=$(git describe --dirty --tags 2>/dev/null)
 then
-	VN=$(echo "$VN" | sed -e 's/-/./g');
+	VN=${VN//-/.}
 else
 	VN="$DEF_VER"
 fi

--- a/GEN-VERSION-FILE
+++ b/GEN-VERSION-FILE
@@ -2,7 +2,7 @@
 # Based on git's GIT-VERSION-GEN.
 
 VF=VERSION-FILE
-DEF_VER=v2.2
+DEF_VER=v0.0
 
 if test -d .git -o -f .git &&
 	VN=$(git describe --dirty --tags 2>/dev/null)

--- a/GEN-VERSION-FILE
+++ b/GEN-VERSION-FILE
@@ -4,18 +4,8 @@
 VF=VERSION-FILE
 DEF_VER=v2.2
 
-LF='
-'
-
 if test -d .git -o -f .git &&
-	VN=$(git describe --abbrev=0 --tags 2>/dev/null) &&
-	case "$VN" in
-	*$LF*) (exit 1) ;;
-	v[0-9]*)
-		git update-index -q --refresh
-		test -z "$(git diff-index --name-only HEAD --)" ||
-		VN="$VN-dirty" ;;
-	esac
+	VN=$(git describe --dirty --tags 2>/dev/null)
 then
 	VN=$(echo "$VN" | sed -e 's/-/./g');
 else

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,19 @@ else
 	datarootdir = $(prefix)/share/bash_completion.d
 endif
 
+# generate list of targets from this Makefile
+# looks for any lowercase target with a double hash mark (##) on the same line
+# and uses the inline comment as the target description
+.PHONY: help
+.DEFAULT: help
+help:                            ## list public targets
+	@echo
+	@echo todo.txt Makefile
+	@echo
+	@sed -ne '/^[a-z%-]\+:.*##/ s/:.*##/\t/p' $(word 1, $(MAKEFILE_LIST)) \
+	 | column -t -s '	'
+	@echo
+
 # Dynamically detect/generate version file as necessary
 # This file will define a variable called VERSION used in
 # both todo.sh and this Makefile.
@@ -126,16 +139,3 @@ test: aggregate-results   ## run tests
 
 # Force tests to get run every time
 .PHONY: test test-pre-clean aggregate-results $(TESTS)
-
-# generate list of targets from this Makefile
-# looks for any lowercase target with a double hash mark (##) on the same line
-# and uses the inline comment as the target description
-.PHONY: help
-.DEFAULT: help
-help:                            ## list public targets
-	@echo
-	@echo todo.txt Makefile
-	@echo
-	@sed -ne '/^[a-z%-]\+:.*##/ s/:.*##/\t/p' $(word 1, $(MAKEFILE_LIST)) \
-	 | column -t -s '	'
-	@echo

--- a/Makefile
+++ b/Makefile
@@ -137,5 +137,5 @@ help:                            ## list public targets
 	@echo todo.txt Makefile
 	@echo
 	@sed -ne '/^[a-z%-]\+:.*##/ s/:.*##/\t/p' $(word 1, $(MAKEFILE_LIST)) \
-	 | column -t -s $$'\t'
+	 | column -t -s '	'
 	@echo


### PR DESCRIPTION
I initially created this fork becaus when I ran `make install` the `VERSION` variable was not updated in `todo.sh`. So `todo -V` would produce:

```text
TODO.TXT Command Line Interface v@DEV_VERSION@
...
```

But now I can't reproduce the problem. Shrug. 

So instead: Here's a nicer Makefile if you want it!

Usage features:

- Separate `make build` command that creates and populates the `todo.txt_cli-*/` directory (and is in turn called by `make dist`.
- A new `make help` command that lists all public targets.

Implementation changes:

- `VERSION-FILE` is no longer generated every time `make` is run, only when required (by `build`/`dist`/`clean` etc, but `test`).
- Refactored the `dist` target into separate file targets which is more atomic and `make` idiomatic. This may or may not be desirable as some people might find it confusing.
- I added a bunch of missing `.PHONY` declarations. 
- Added lots of comments.

You can verify that the dist files are still generated correctly with the following:

```bash
mkdir -p tmp && cd tmp
git clone git@github.com:todotxt/todo.txt-cli.git todo
git clone --branch makefile git@github.com:alissa-huskey/todo.txt-cli.git todo-fork
mkdir dist dist-fork
make -C todo dist && make -C todo-fork dist
tar xzvf todo/*.tar.gz --directory ./dist && tar xzvf todo-fork/*.tar.gz --directory dist-fork

# confirm they contain the same files
diff <(ls dist/todo*/) <(ls dist-fork/todo*/)

# confirm the contents of all files are the same
for f in dist/todo*/*; do diff -w ${f} dist-fork/todo*/${f##*/} ; done
```

Hope you find it useful!