### PR TITLE
ENH: Reuse the todo.sh alias for completion

### DIFF
--- a/tests/t6090-completion-aliases.sh
+++ b/tests/t6090-completion-aliases.sh
@@ -46,15 +46,22 @@ test_todo_session 'todo 1 and 2 contexts' <<EOF
 EOF
 
 # Define a second completion function that injects the different configuration
-# file. In real use, this would be installed via
+# file and uppercases all output. (This is a silly behavior change that still
+# requires a completion function override.)
+# In real use, this would be installed via
 #   complete -F _todo2 todo2
+_uppercase_todo()
+{
+    todo.sh "$@" | tr '[:lower:]' '[:upper:]'
+}
 _todo2()
 {
-    local _todo_sh='todo.sh -d "$HOME/todo2.cfg"'
+    local _todo_sh='_uppercase_todo -d "$HOME/todo2.cfg"'
     _todo "$@"
 }
 
 test_todo_completion               'all todo1 contexts' 'todo1 list @' '@garden @outdoor @outside'
-test_todo_custom_completion _todo2 'all todo2 contexts' 'todo2 list @' '@home @oriental'
+test_todo_completion               'all todo2 contexts' 'todo2 list @' '@home @oriental'
+test_todo_custom_completion _todo2 'all uppercased todo2 contexts' 'doesNotMatter list @' '@HOME @ORIENTAL'
 
 test_done

--- a/todo_completion
+++ b/todo_completion
@@ -18,7 +18,7 @@ _todo()
         mv prepend prep pri p replace report shorthelp"
     local -r MOVE_COMMAND_PATTERN='move|mv'
 
-    local _todo_sh=${_todo_sh:-todo.sh}
+    local _todo_sh=${_todo_sh:-${COMP_WORDS[0]}}
     local completions
     if [ "$COMP_CWORD" -eq 1 ]; then
         completions="$COMMANDS $(eval TODOTXT_VERBOSE=0 $_todo_sh command listaddons 2>/dev/null) $OPTS"
@@ -101,22 +101,14 @@ complete -F _todo todo.sh
 # ~/.bashrc (or wherever else you're defining your alias). If you simply
 # uncomment it here, you will need to redo this on every todo.txt update!
 
-# If you have renamed the todo.sh executable, or if it is not accessible through
-# PATH, you need to add and use a wrapper completion function, like this:
-#_todoElsewhere()
+# The completion uses the alias itself, so any custom arguments (like a custom
+# configuration (-d "$HOME/todo2.cfg")) are used there as well.
+# If you don't want this, or need to further tweak the todo.sh command that's
+# used by the completion, you can add and use a wrapper completion function that
+# redefines _todo_sh before invoking _todo():
+#_todo_tweak()
 #{
-#    local _todo_sh='/path/to/todo2.sh'
+#    local _todo_sh='todo.sh -d "$HOME/todo-tweaked.cfg"'
 #    _todo "$@"
 #}
-#complete -F _todoElsewhere /path/to/todo2.sh
-
-# If you use aliases to use different configuration(s), you need to add and use
-# a wrapper completion function for each configuration if you want to complete
-# from the actual configured task locations:
-#alias todo2='todo.sh -d "$HOME/todo2.cfg"'
-#_todo2()
-#{
-#    local _todo_sh='todo.sh -d "$HOME/todo2.cfg"'
-#    _todo "$@"
-#}
-#complete -F _todo2 todo2
+#complete -F _todo_tweak todo.sh


### PR DESCRIPTION
Having to define a completion function wrapper is cumbersome. I had seen the trick of simply using `${COMP_WORDS[0]}` (i.e. the used `todo.sh` command itself) from Paul Mansfield (https://github.com/the1ts/todo.txt-plugins/blob/develop/bash_completion/todo.txt#L7), which neatly avoids this.
By keeping the `_todo_sh` variable, this is a one-line change and it still allows the old way of using the override in a wrapper function. (So users aren't forced to change their customizations when upgrading.)
Tests are adapted to verify that the alias is used, and still verify the wrapper function as well.
The documentation is simplified because there's normally no need for the completion wrapper function.


**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [X] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [ ] ~~Steps for the reviewer(s) on how they can manually QA the changes.~~
- [ ] ~~Have a `fixes #XX` reference to the issue that this pull request fixes.~~