### PR TITLE
Build: Tests: "make test" now fails if there are failing or broken tests

### DIFF
--- a/tests/aggregate-results.sh
+++ b/tests/aggregate-results.sh
@@ -44,7 +44,7 @@ get_color()
 	# Only use the supplied color if there are actually instances of that
 	# type, so that a clean test run does not distract the user by the
 	# appearance of the error highlighting.
-	if [ ${1:?} -eq 0 ]
+	if [ "${1:?}" -eq 0 ]
 	then
 		echo 'info'
 	else
@@ -61,21 +61,21 @@ total=0
 
 for file
 do
-	while read type value
+	while read -r type value
 	do
 		case $type in
 		'')
 			continue ;;
 		fixed)
-			fixed=$((fixed + $value)) ;;
+			fixed=$((fixed + value)) ;;
 		success)
-			success=$((success + $value)) ;;
+			success=$((success + value)) ;;
 		failed)
-			failed=$((failed + $value)) ;;
+			failed=$((failed + value)) ;;
 		broken)
-			broken=$((broken + $value)) ;;
+			broken=$((broken + value)) ;;
 		total)
-			total=$((total + $value)) ;;
+			total=$((total + value)) ;;
 		esac
 	done <"$file"
 done
@@ -86,4 +86,4 @@ say_color "$(get_color "$failed" 'error')" "$(printf "%-8s%d\n" failed $failed)"
 say_color "$(get_color "$broken" 'error')" "$(printf "%-8s%d\n" broken $broken)"
 say_color 'info'                           "$(printf "%-8s%d\n" total $total)"
 
-[ $broken -eq 0 -a $failed -eq 0 ]
+[ $broken -eq 0 ] && [ $failed -eq 0 ]

--- a/tests/aggregate-results.sh
+++ b/tests/aggregate-results.sh
@@ -18,12 +18,11 @@ if test -n "$color"; then
 	say_color() {
 		(
 		export TERM
-		case "$1" in
+		case "${1:?}" in
 			error) tput bold; tput setaf 1;; # bold red
 			skip)  tput bold; tput setaf 2;; # bold green
 			pass)  tput setaf 2;;            # green
 			info)  tput setaf 3;;            # brown
-			*) test -n "$quiet" && return;;
 		esac
 		shift
 		printf "* %s" "$*"
@@ -33,7 +32,6 @@ if test -n "$color"; then
 	}
 else
 	say_color() {
-		test -z "$1" && test -n "$quiet" && return
 		shift
 		echo "* $*"
 	}

--- a/tests/aggregate-results.sh
+++ b/tests/aggregate-results.sh
@@ -85,3 +85,5 @@ say_color "$(get_color "$success" 'pass')" "$(printf "%-8s%d\n" success $success
 say_color "$(get_color "$failed" 'error')" "$(printf "%-8s%d\n" failed $failed)"
 say_color "$(get_color "$broken" 'error')" "$(printf "%-8s%d\n" broken $broken)"
 say_color 'info'                           "$(printf "%-8s%d\n" total $total)"
+
+[ $broken -eq 0 -a $failed -eq 0 ]

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -316,64 +316,6 @@ expected exit code $1, actual ${eval_ret}"
 	echo >&3 ""
 }
 
-# test_external runs external test scripts that provide continuous
-# test output about their progress, and succeeds/fails on
-# zero/non-zero exit code.  It outputs the test output on stdout even
-# in non-verbose mode, and announces the external script with "* run
-# <n>: ..." before running it.  When providing relative paths, keep in
-# mind that all scripts run in "trash directory".
-# Usage: test_external description command arguments...
-# Example: test_external 'Perl API' perl ../path/to/test.pl
-test_external () {
-	test "$#" -eq 3 ||
-	error >&5 "bug in the test script: not 3 parameters to test_external"
-	descr="$1"
-	shift
-	if ! test_skip "$descr" "$@"
-	then
-		# Announce the script to reduce confusion about the
-		# test output that follows.
-		say_color "" " run $test_count: $descr ($*)"
-		# Run command; redirect its stderr to &4 as in
-		# test_run_, but keep its stdout on our stdout even in
-		# non-verbose mode.
-		"$@" 2>&4
-		if [ "$?" = 0 ]
-		then
-			test_ok_ "$descr"
-		else
-			test_failure_ "$descr" "$@"
-		fi
-	fi
-}
-
-# Like test_external, but in addition tests that the command generated
-# no output on stderr.
-test_external_without_stderr () {
-	# The temporary file has no (and must have no) security
-	# implications.
-	tmp="$TMPDIR"; if [ -z "$tmp" ]; then tmp=/tmp; fi
-	stderr="$tmp/todotxt-external-stderr.$$.tmp"
-	test_external "$@" 4> "$stderr"
-	[ -f "$stderr" ] || error "Internal error: $stderr disappeared."
-	descr="no stderr: $1"
-	shift
-	say >&3 "expecting no stderr from previous command"
-	if [ ! -s "$stderr" ]; then
-		rm "$stderr"
-		test_ok_ "$descr"
-	else
-		if [ "$verbose" = t ]; then
-			output=$(echo; echo Stderr is:; cat "$stderr")
-		else
-			output=
-		fi
-		# rm first in case test_failure exits.
-		rm "$stderr"
-		test_failure_ "$descr" "$@" "$output"
-	fi
-}
-
 # This is not among top-level (test_expect_success | test_expect_failure)
 # but is a prefix that can be used in the test script, like:
 #


### PR DESCRIPTION
`aggregate-results.sh` just reports the execution status, but succeeds in all cases.
The build should fail if there are errors. (This also means that no cleanup runs and the failures can be investigated in more detail.)


**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] If you've added code that should be tested, add tests!
- [x] Ensure the test suite passes.
- [x] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [ ] Include a human-readable description of what the pull request is trying to accomplish.
- [x] Steps for the reviewer(s) on how they can manually QA the changes: Make a test fail, run `$ make test`, observe exit status 1
- [ ] Have a `fixes #XX` reference to the issue that this pull request fixes.