### PR TITLE
Improve GNU sed fallback while allowing use of -i.bak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,9 @@ clean: test-pre-clean VERSION-FILE   ## remove dist directory and all release fi
 install: build installdirs   ## local package install
 	$(INSTALL_PROGRAM) $(DISTNAME)/todo.sh $(DEST_COMMAND)
 	$(INSTALL_DATA) $(DISTNAME)/todo_completion $(DEST_COMPLETION)
-	[ -e $(DEST_CONFIG) ] || \
-	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" $(DISTNAME)/todo.cfg > $(DEST_CONFIG)
+	if [ ! -e $(DEST_CONFIG) ]; then \
+	    sed 's@^\(export TODO_DIR=\).*@\1~/.todo@' $(DISTNAME)/todo.cfg > $(DEST_CONFIG); \
+	fi
 
 .PHONY: uninstall
 uninstall:   ## uninstall package

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,12 @@ install: build installdirs   ## local package install
 	$(INSTALL_DATA) $(DISTNAME)/todo_completion $(DEST_COMPLETION)
 	if [ ! -e $(DEST_CONFIG) ]; then \
 	    sed 's@^\(export TODO_DIR=\).*@\1~/.todo@' $(DISTNAME)/todo.cfg > $(DEST_CONFIG); \
+	    if sed -i.bak 's@^# \(export TODOTXT_SED_COMMAND=sed\)$$@\1@' $(DEST_CONFIG) 2>/dev/null; then \
+	        rm -f $(DEST_CONFIG).bak; \
+	        echo 'This sed supports in-place editing.'; \
+	    else \
+	        echo 'Need sed in-place emulation here.'; \
+	    fi; \
 	fi
 
 .PHONY: uninstall

--- a/todo.cfg
+++ b/todo.cfg
@@ -106,3 +106,8 @@ export REPORT_FILE="$TODO_DIR/report.txt"
 # If you have GNU sed or another sed that supports in-place editing
 # via -i[SUFFIX], uncomment this for a minuscule performance gain.
 # export TODOTXT_SED_COMMAND=sed
+
+# Uncomment this if you have add-ons that also do in-place editing
+# via sed, pass the -i.bak as the first argument like todo.sh itself,
+# and your system needs the in-place emulation.
+# export TODOTXT_SED_EXPORT_FOR_ADDONS=1

--- a/todo.cfg
+++ b/todo.cfg
@@ -101,3 +101,8 @@ export REPORT_FILE="$TODO_DIR/report.txt"
 # Set a default action for calling todo.sh without arguments.
 # Also allows for parameters for the action.
 # export TODOTXT_DEFAULT_ACTION=''
+
+## sed capabilities
+# If you have GNU sed or another sed that supports in-place editing
+# via -i[SUFFIX], uncomment this for a minuscule performance gain.
+# export TODOTXT_SED_COMMAND=sed

--- a/todo.sh
+++ b/todo.sh
@@ -27,6 +27,24 @@ export TODO_SH TODO_FULL_SH
 
 oneline_usage="$TODO_SH [-fhpantvV] [-d todo_config] action [task_number] [task_description]"
 
+# Assumption: The in-place argument is the first
+# Assumption: Only a single file is processed with sed
+sed() {
+    if command -v gsed &>/dev/null; then
+        gsed "$@"
+    elif [ "$1" = '-i.bak' ]; then
+        if ! shift; then
+            die "Failed to shift"
+        fi
+
+        filepath=${!#}
+        filepath_temp=/tmp/todo.sh-sed.$RANDOM.$$
+        command sed "$@" > "$filepath_temp" && mv "$filepath_temp" "$filepath"
+    else
+        command sed "$@"
+    fi
+}
+
 usage()
 {
     cat <<-EndUsage

--- a/todo.sh
+++ b/todo.sh
@@ -43,6 +43,8 @@ sed() {
         command sed "$@"
     fi
 }
+[ "$TODOTXT_SED_EXPORT_FOR_ADDONS" = 1 ] \
+    && export -f sed
 
 usage()
 {

--- a/todo.sh
+++ b/todo.sh
@@ -33,10 +33,7 @@ sed() {
     if command -v gsed &>/dev/null; then
         gsed "$@"
     elif [ "$1" = '-i.bak' ]; then
-        if ! shift; then
-            die "Failed to shift"
-        fi
-
+        shift
         filepath=${!#}
         filepath_temp=/tmp/todo.sh-sed.$RANDOM.$$
         command sed "$@" > "$filepath_temp" && mv "$filepath_temp" "$filepath"

--- a/todo.sh
+++ b/todo.sh
@@ -37,7 +37,7 @@ sed() {
     elif [ "$1" = '-i.bak' ]; then
         shift
         filepath=${!#}
-        filepath_temp=/tmp/todo.sh-sed.$RANDOM.$$
+        filepath_temp=${TMPDIR-/tmp}/todo.sh-sed.$RANDOM.$$
         command sed "$@" > "$filepath_temp" && mv "$filepath_temp" "$filepath"
     else
         command sed "$@"

--- a/todo.sh
+++ b/todo.sh
@@ -30,7 +30,9 @@ oneline_usage="$TODO_SH [-fhpantvV] [-d todo_config] action [task_number] [task_
 # Assumption: The in-place argument is the first
 # Assumption: Only a single file is processed with sed
 sed() {
-    if command -v gsed &>/dev/null; then
+    if [ -n "$TODOTXT_SED_COMMAND" ]; then
+        command "$TODOTXT_SED_COMMAND" "$@"
+    elif command -v gsed &>/dev/null; then
         gsed "$@"
     elif [ "$1" = '-i.bak' ]; then
         shift


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [X] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes.
- [X] Have a `fixes #XX` reference to the issue that this pull request fixes.

This builds upon #421, but adds a new `TODOTXT_SED_COMMAND` config variable to allow (Linux and Cygwin) users who have GNU sed to skip the less efficient emulation.

It also adds a `TODOTXT_SED_EXPORT_FOR_ADDONS` flag that exports the `sed()` wrapper for use of (compatible) add-ons.