### PR TITLE
BUG: Correct Bash completion path in Makefile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,4 +18,6 @@ jobs:
     - run: make
     - run: make dist
     - run: make test
-
+    - run: sudo make install
+    - run: sudo make uninstall
+    - run: sudo make clean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `TODOTXT_DEFAULT_ACTION` now also allows action parameters ([#159], [#407])
 
+### Fixed
+- `make install` installed the Bash completion in the wrong directory ([#452])
+- `make uninstall` fails ([#451])
+
 ## [2.13.0] - 2024-12-25
 
 ### Added
@@ -541,3 +545,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [#359]: https://github.com/todotxt/todo.txt-cli/pull/359
 [#386]: https://github.com/todotxt/todo.txt-cli/pull/386
 [#407]: https://github.com/todotxt/todo.txt-cli/pull/407
+[#451]: https://github.com/todotxt/todo.txt-cli/pull/451
+[#452]: https://github.com/todotxt/todo.txt-cli/pull/452

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ ifdef INSTALL_DIR
 else
 	bindir = $(prefix)/bin
 endif
+DEST_COMMAND = $(DESTDIR)$(bindir)/todo.sh
 
 # The directory to install the config file in.
 ifdef CONFIG_DIR
@@ -26,12 +27,14 @@ ifdef CONFIG_DIR
 else
 	sysconfdir = $(prefix)/etc
 endif
+DEST_CONFIG = $(DESTDIR)$(sysconfdir)/todo/config
 
 ifdef BASH_COMPLETION
 	datarootdir = $(BASH_COMPLETION)
 else
 	datarootdir = $(prefix)/share/bash_completion.d
 endif
+DEST_COMPLETION = $(DESTDIR)$(datarootdir)/todo.sh
 
 # generate list of targets from this Makefile
 # looks for any lowercase target with a double hash mark (##) on the same line
@@ -95,16 +98,16 @@ clean: test-pre-clean VERSION-FILE   ## remove dist directory and all release fi
 
 .PHONY: install
 install: build installdirs   ## local package install
-	$(INSTALL_PROGRAM) $(DISTNAME)/todo.sh $(DESTDIR)$(bindir)/todo.sh
-	$(INSTALL_DATA) $(DISTNAME)/todo_completion $(DESTDIR)$(datarootdir)/todo.sh
-	[ -e $(DESTDIR)$(sysconfdir)/todo/config ] || \
-	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" $(DISTNAME)/todo.cfg > $(DESTDIR)$(sysconfdir)/todo/config
+	$(INSTALL_PROGRAM) $(DISTNAME)/todo.sh $(DEST_COMMAND)
+	$(INSTALL_DATA) $(DISTNAME)/todo_completion $(DEST_COMPLETION)
+	[ -e $(DEST_CONFIG) ] || \
+	    sed "s/^\(export[ \t]*TODO_DIR=\).*/\1~\/.todo/" $(DISTNAME)/todo.cfg > $(DEST_CONFIG)
 
 .PHONY: uninstall
 uninstall:   ## uninstall package
-	rm -f $(DESTDIR)$(bindir)/todo.sh
-	rm -f $(DESTDIR)$(datarootdir)/todo.sh
-	rm -f $(DESTDIR)$(sysconfdir)/todo/config
+	rm -f $(DEST_COMMAND)
+	rm -f $(DEST_COMPLETION)
+	rm -f $(DEST_CONFIG)
 
 	rmdir $(DESTDIR)$(datarootdir)
 	rmdir $(DESTDIR)$(sysconfdir)/todo

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ install: build installdirs   ## local package install
 .PHONY: uninstall
 uninstall:   ## uninstall package
 	rm -f $(DESTDIR)$(bindir)/todo.sh
-	rm -f $(DESTDIR)$(datarootdir)/todo
+	rm -f $(DESTDIR)$(datarootdir)/todo.sh
 	rm -f $(DESTDIR)$(sysconfdir)/todo/config
 
 	rmdir $(DESTDIR)$(datarootdir)

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ uninstall:   ## uninstall package
 	rm -f $(DEST_COMPLETION)
 	rm -f $(DEST_CONFIG)
 
-	rmdir $(DESTDIR)$(datarootdir)
+	rmdir $(DESTDIR)$(datarootdir) 2>/dev/null || :
 	rmdir $(DESTDIR)$(sysconfdir)/todo
 
 # create local installation directories

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DEST_CONFIG = $(DESTDIR)$(sysconfdir)/todo/config
 ifdef BASH_COMPLETION
 	datarootdir = $(BASH_COMPLETION)
 else
-	datarootdir = $(prefix)/share/bash_completion.d
+	datarootdir = $(prefix)/share/bash-completion/completions
 endif
 DEST_COMPLETION = $(DESTDIR)$(datarootdir)/todo.sh
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ make test
 
 - `INSTALL_DIR`: PATH for executables (default /usr/local/bin)
 - `CONFIG_DIR`: PATH for the todo.txt configuration template
-- `BASH_COMPLETION`: PATH for autocompletion scripts (default to /etc/bash_completion.d)
+- `BASH_COMPLETION`: PATH for autocompletion scripts (default to `/usr/local/share/bash-completion/completions`)
 
 ```shell
 make install CONFIG_DIR=/etc INSTALL_DIR=/usr/bin BASH_COMPLETION=/usr/share/bash-completion/completions

--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ make test
 
 *NOTE:* Makefile defaults to several default paths for installed files. Adjust to your system:
 
-- `INSTALL_DIR`: PATH for executables (default /usr/local/bin)
-- `CONFIG_DIR`: PATH for the todo.txt configuration template
+- `INSTALL_DIR`: PATH for executables (default `/usr/local/bin`)
+- `CONFIG_DIR`: PATH for the `todo/config` configuration template (default `/usr/local/etc`)
 - `BASH_COMPLETION`: PATH for autocompletion scripts (default to `/usr/local/share/bash-completion/completions`)
 
 ```shell
-make install CONFIG_DIR=/etc INSTALL_DIR=/usr/bin BASH_COMPLETION=/usr/share/bash-completion/completions
+# Note: Showcasing config overrides for legacy locations; NOT recommended!
+make install CONFIG_DIR=/etc INSTALL_DIR=/usr/bin BASH_COMPLETION=/etc/bash_completion.d
 ```
 
 #### Arch Linux (AUR)


### PR DESCRIPTION
**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [X] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes.
- [X] Have a fixes #451 reference to the issue that this pull request fixes.

The correct one is `/usr/local/share/bash-completion/completions/todo.sh`; previous adaptations away from the legacy `/etc/bash_completion.d/todo` location were incomplete, also due to duplication in the Makefile.