### PR TITLE
Add TODOTXT_DATE_FORMAT environment variable

### DIFF
--- a/tests/t1011-add-format-date.sh
+++ b/tests/t1011-add-format-date.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+test_description='test TODOTXT_DATE_FORMAT environment variable
+
+Ensure that the date format of creation and completion dates is correct
+'
+. ./test-lib.sh
+
+
+unset TODOTXT_DATE_FORMAT
+test_todo_session 'default date format with env var unset' <<EOF
+>>> todo.sh -t add Solve the halting problem
+1 2009-02-13 Solve the halting problem
+TODO: 1 added.
+
+>>> todo.sh list
+1 2009-02-13 Solve the halting problem
+--
+TODO: 1 of 1 tasks shown
+EOF
+
+export TODOTXT_DATE_FORMAT="%Y-%m-%dT%H:%M:%S%z"
+test_todo_session 'ISO-8601 with seconds and timezone' <<EOF
+>>> todo.sh -t add Solve the halting problem
+2 2009-02-13T04:40:00+0000 Solve the halting problem
+TODO: 2 added.
+
+>>> todo.sh list
+1 2009-02-13 Solve the halting problem
+2 2009-02-13T04:40:00+0000 Solve the halting problem
+--
+TODO: 2 of 2 tasks shown
+EOF
+
+test_todo_session 'ISO-8601 completion date' <<EOF
+>>> todo.sh -t done 2
+2 x 2009-02-13T04:40:00+0000 2009-02-13T04:40:00+0000 Solve the halting problem
+TODO: 2 marked as done.
+x 2009-02-13T04:40:00+0000 2009-02-13T04:40:00+0000 Solve the halting problem
+TODO: $HOME/todo.txt archived.
+
+>>> todo.sh listall
+1 2009-02-13 Solve the halting problem
+[0;37m0 x 2009-02-13T04:40:00+0000 2009-02-13T04:40:00+0000 Solve the halting problem[0m
+--
+TODO: 1 of 1 tasks shown
+DONE: 1 of 1 tasks shown
+total 2 of 2 tasks shown
+EOF
+
+test_done

--- a/todo.sh
+++ b/todo.sh
@@ -151,6 +151,7 @@ $indentedJoinedConfigFileLocations
 		    TODOTXT_DEFAULT_ACTION=""       run this when called with no arguments
 		    TODOTXT_SORT_COMMAND="sort ..." customize list output
 		    TODOTXT_FINAL_FILTER="sed ..."  customize list after color, P@+ hiding
+		    TODOTXT_DATE_FORMAT="%Y-%m-%d"  customize creation/completion date format
 		    TODOTXT_SOURCEVAR=\$DONE_FILE   use another source for listcon, listproj
 		    TODOTXT_SIGIL_BEFORE_PATTERN="" optionally allow chars preceding +p / @c
 		    TODOTXT_SIGIL_VALID_PATTERN=.*  tweak the allowed chars for +p and @c
@@ -524,6 +525,7 @@ OVR_TODOTXT_AUTO_ARCHIVE="$TODOTXT_AUTO_ARCHIVE"
 OVR_TODOTXT_FORCE="$TODOTXT_FORCE"
 OVR_TODOTXT_PRESERVE_LINE_NUMBERS="$TODOTXT_PRESERVE_LINE_NUMBERS"
 OVR_TODOTXT_PLAIN="$TODOTXT_PLAIN"
+OVR_TODOTXT_DATE_FORMAT="$TODOTXT_DATE_FORMAT"
 OVR_TODOTXT_DATE_ON_ADD="$TODOTXT_DATE_ON_ADD"
 OVR_TODOTXT_PRIORITY_ON_ADD="$TODOTXT_PRIORITY_ON_ADD"
 OVR_TODOTXT_DISABLE_FILTER="$TODOTXT_DISABLE_FILTER"
@@ -642,6 +644,7 @@ TODOTXT_PLAIN=${TODOTXT_PLAIN:-0}
 TODOTXT_FORCE=${TODOTXT_FORCE:-0}
 TODOTXT_PRESERVE_LINE_NUMBERS=${TODOTXT_PRESERVE_LINE_NUMBERS:-1}
 TODOTXT_AUTO_ARCHIVE=${TODOTXT_AUTO_ARCHIVE:-1}
+TODOTXT_DATE_FORMAT=${TODOTXT_DATE_FORMAT:-%Y-%m-%d}
 TODOTXT_DATE_ON_ADD=${TODOTXT_DATE_ON_ADD:-0}
 TODOTXT_PRIORITY_ON_ADD=${TODOTXT_PRIORITY_ON_ADD:-}
 TODOTXT_DEFAULT_ACTION=${TODOTXT_DEFAULT_ACTION:-}
@@ -747,6 +750,9 @@ fi
 if [ -n "$OVR_TODOTXT_PLAIN" ]; then
     TODOTXT_PLAIN="$OVR_TODOTXT_PLAIN"
 fi
+if [ -n "$OVR_TODOTXT_DATE_FORMAT" ]; then
+    TODOTXT_DATE_FORMAT="$OVR_TODOTXT_DATE_FORMAT"
+fi
 if [ -n "$OVR_TODOTXT_DATE_ON_ADD" ]; then
     TODOTXT_DATE_ON_ADD="$OVR_TODOTXT_DATE_ON_ADD"
 fi
@@ -818,7 +824,7 @@ _addto()
 
     if [[ "$TODOTXT_DATE_ON_ADD" -eq 1 ]]; then
         local now
-        now=$(date '+%Y-%m-%d')
+        now=$(date "+$TODOTXT_DATE_FORMAT")
         input=$(echo "$input" | sed -e 's/^\(([A-Z]) \)\{0,1\}/\1'"$now /")
     fi
     if [[ -n "$TODOTXT_PRIORITY_ON_ADD" ]]; then
@@ -1261,7 +1267,7 @@ case $action in
 
         # Check if this item has already been done
         if [ "${todo:0:2}" != "x " ]; then
-            now=$(date '+%Y-%m-%d')
+            now=$(date "+$TODOTXT_DATE_FORMAT")
             # remove priority once item is done
             sed -i.bak "${item}s/^(.) //" "$TODO_FILE"
             sed -i.bak "${item}s|^|x $now |" "$TODO_FILE"


### PR DESCRIPTION
TODOTXT_DATE_FORMAT sets the format of creation and completion dates. Prior to this commit, the format was hard-coded to %Y-%m-%d.

This commit fixes #456.

Reviewers: test this feature by setting `TODOTXT_DATE_FORMAT`.
```sh
export TODOTXT_DATE_FORMAT="%Y-%m-%dT%H:%M:%S%z"
t add Solve the halting problem
t list
# 1 2009-02-13T04:40:00+0000 Solve the halting problem
t done 1
t listall
# 0 x 2009-02-13T04:40:00+0000 2009-02-13T04:40:00+0000 Solve the halting problem
```

**Before submitting a pull request,** please make sure the following is done:

- [x] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [x] If you've added code that should be tested, add tests!
- [x] Ensure the test suite passes.
- [x] Lint your code with [ShellCheck](https://www.shellcheck.net/).

There are a couple of quote warnings, not related to my code. Happy to fix in a different commit if needed.

- [x] Include a human-readable description of what the pull request is trying to accomplish.
- [x] Steps for the reviewer(s) on how they can manually QA the changes.
- [x] Have a `fixes #XX` reference to the issue that this pull request fixes.
