### PR TITLE
ENH: Config should allow external override of file locations

### DIFF
--- a/tests/t1050-todofile-override.sh
+++ b/tests/t1050-todofile-override.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+
+test_description='override of TODO_FILE config location
+
+This test ensures that the TODO_FILE config location can be overridden via
+environment variable.
+'
+. ./test-lib.sh
+
+test_todo_session 'add/list with override' <<EOF
+>>> todo.sh add notice the daisies
+1 notice the daisies
+TODO: 1 added.
+
+>>> todo.sh list
+1 notice the daisies
+--
+TODO: 1 of 1 tasks shown
+
+>>> TODO_FILE="$HOME/special.txt" todo.sh add smell the roses
+1 smell the roses
+SPECIAL: 1 added.
+
+>>> todo.sh list
+1 notice the daisies
+--
+TODO: 1 of 1 tasks shown
+
+>>> TODO_FILE="$HOME/special.txt" todo.sh list
+1 smell the roses
+--
+SPECIAL: 1 of 1 tasks shown
+EOF
+
+test_todo_session 'do with override' <<EOF
+>>> DONE_FILE="$HOME/specialdone.txt" todo.sh do 1
+1 x 2009-02-13 notice the daisies
+TODO: 1 marked as done.
+x 2009-02-13 notice the daisies
+TODO: $HOME/todo.txt archived.
+
+>>> TODO_FILE="$HOME/special.txt" DONE_FILE="$HOME/specialdone.txt" todo.sh do 1
+1 x 2009-02-13 smell the roses
+TODO: 1 marked as done.
+x 2009-02-13 smell the roses
+TODO: $HOME/special.txt archived.
+
+>>> todo.sh -p listfile specialdone.txt
+1 x 2009-02-13 notice the daisies
+2 x 2009-02-13 smell the roses
+--
+SPECIALDONE: 2 of 2 tasks shown
+EOF
+
+test_done

--- a/tests/t1950-report.sh
+++ b/tests/t1950-report.sh
@@ -93,4 +93,11 @@ TODO: Report file is up-to-date.
 2009-02-13T04:40:00 3 2
 EOF
 
+test_todo_session 'report with override' <<EOF
+>>> REPORT_FILE="$HOME/specialreport.txt" todo.sh report
+TODO: $HOME/todo.txt does not contain any done tasks.
+2009-02-13T04:40:00 3 2
+TODO: Report file updated.
+EOF
+
 test_done

--- a/todo.cfg
+++ b/todo.cfg
@@ -2,12 +2,14 @@
 
 # Your todo.txt directory (this should be an absolute path)
 #export TODO_DIR="/Users/gina/Documents/todo"
-export TODO_DIR=${HOME:-$USERPROFILE}
+: ${TODO_DIR:="${HOME:-$USERPROFILE}"}
+export TODO_DIR
 
 # Your todo/done/report.txt locations
-export TODO_FILE="$TODO_DIR/todo.txt"
-export DONE_FILE="$TODO_DIR/done.txt"
-export REPORT_FILE="$TODO_DIR/report.txt"
+: ${TODO_FILE:="${TODO_DIR}/todo.txt"}
+: ${DONE_FILE:="${TODO_DIR}/done.txt"}
+: ${REPORT_FILE:="${TODO_DIR}/report.txt"}
+export TODO_FILE DONE_FILE REPORT_FILE
 
 # You can customize your actions directory location
 #export TODO_ACTIONS_DIR="$HOME/.todo.actions.d"


### PR DESCRIPTION
E.g. on the command-line:

    $ TODO_FILE=/path/to/other.txt todo.sh lsc

Or through aliases that customize todo.sh for particular todo files:

    alias todoinbox='TODO_FILE=/path/to/inbox.txt todo.sh'

Only non-empty values will override the config default.

Cp. https://github.com/todotxt/todo.txt-cli/discussions/459


**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [X] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes.
- [ ] ~~Have a `fixes #XX` reference to the issue that this pull request fixes.~~