### PR TITLE
UI: ENH: Mention destination task NR on move and only use file prefixes

### DIFF
--- a/tests/t1850-move.sh
+++ b/tests/t1850-move.sh
@@ -15,7 +15,7 @@ EOF
 test_todo_session 'basic move with implicit source' <<EOF
 >>> todo.sh -f move 1 done.txt | sed "s#'[^']\{1,\}/\([^/']\{1,\}\)'#'\1'#g"
 1 (B) smell the uppercase Roses +flowers @outside
-TODO: 1 moved from 'todo.txt' to 'done.txt'.
+TODO: 1 moved to DONE.
 
 >>> todo.sh -p ls
 2 (A) notice the sunflowers
@@ -42,7 +42,7 @@ test_todo_session 'basic move with confirmation' <<EOF
 >>> printf y | todo.sh move 1 done.txt 2>&1 | sed -e "s#'[^']\{1,\}/\([^/']\{1,\}\)'#'\1'#g" -e 's#from .\{1,\}/\([^/]\{1,\}\) to .\{1,\}/\([^/]\{1,\}\)?#from \1 to \2?#g'
 \\
 1 (B) smell the uppercase Roses +flowers @outside
-TODO: 1 moved from 'todo.txt' to 'done.txt'.
+TODO: 1 moved to DONE.
 
 >>> todo.sh -p ls
 2 (A) notice the sunflowers
@@ -60,7 +60,7 @@ EOF
 test_todo_session 'basic move with passed source' <<EOF
 >>> todo.sh -f move 2 todo.txt done.txt | sed "s#'[^']\{1,\}/\([^/']\{1,\}\)'#'\1'#g"
 2 x 2009-02-13 smell the coffee +wakeup
-TODO: 2 moved from 'done.txt' to 'todo.txt'.
+DONE: 2 moved to TODO.
 
 >>> todo.sh -p ls
 2 (A) notice the sunflowers
@@ -83,7 +83,7 @@ EOF
 test_todo_session 'move to destination without EOL' <<EOF
 >>> todo.sh -f move 2 todo.txt done.txt | sed "s#'[^']\{1,\}/\([^/']\{1,\}\)'#'\1'#g"
 2 x 2009-02-13 smell the coffee +wakeup
-TODO: 2 moved from 'done.txt' to 'todo.txt'.
+DONE: 2 moved to TODO.
 
 >>> todo.sh -p ls
 1 this is a first task without newline

--- a/tests/t1850-move.sh
+++ b/tests/t1850-move.sh
@@ -15,7 +15,7 @@ EOF
 test_todo_session 'basic move with implicit source' <<EOF
 >>> todo.sh -f move 1 done.txt | sed "s#'[^']\{1,\}/\([^/']\{1,\}\)'#'\1'#g"
 1 (B) smell the uppercase Roses +flowers @outside
-TODO: 1 moved to DONE.
+TODO: 1 moved to 3 in DONE.
 
 >>> todo.sh -p ls
 2 (A) notice the sunflowers
@@ -42,7 +42,7 @@ test_todo_session 'basic move with confirmation' <<EOF
 >>> printf y | todo.sh move 1 done.txt 2>&1 | sed -e "s#'[^']\{1,\}/\([^/']\{1,\}\)'#'\1'#g" -e 's#from .\{1,\}/\([^/]\{1,\}\) to .\{1,\}/\([^/]\{1,\}\)?#from \1 to \2?#g'
 \\
 1 (B) smell the uppercase Roses +flowers @outside
-TODO: 1 moved to DONE.
+TODO: 1 moved to 3 in DONE.
 
 >>> todo.sh -p ls
 2 (A) notice the sunflowers
@@ -60,7 +60,7 @@ EOF
 test_todo_session 'basic move with passed source' <<EOF
 >>> todo.sh -f move 2 todo.txt done.txt | sed "s#'[^']\{1,\}/\([^/']\{1,\}\)'#'\1'#g"
 2 x 2009-02-13 smell the coffee +wakeup
-DONE: 2 moved to TODO.
+DONE: 2 moved to 3 in TODO.
 
 >>> todo.sh -p ls
 2 (A) notice the sunflowers
@@ -83,7 +83,7 @@ EOF
 test_todo_session 'move to destination without EOL' <<EOF
 >>> todo.sh -f move 2 todo.txt done.txt | sed "s#'[^']\{1,\}/\([^/']\{1,\}\)'#'\1'#g"
 2 x 2009-02-13 smell the coffee +wakeup
-DONE: 2 moved to TODO.
+DONE: 2 moved to 2 in TODO.
 
 >>> todo.sh -p ls
 1 this is a first task without newline

--- a/todo.sh
+++ b/todo.sh
@@ -1394,10 +1394,10 @@ case $action in
 
         if [ "$TODOTXT_VERBOSE" -gt 0 ]; then
             echo "$item $todo"
-            echo "TODO: $item moved from '$src' to '$dest'."
+            echo "$(getPrefix "$src"): $item moved to $(getPrefix "$dest")."
         fi
     else
-        die "TODO: No tasks moved."
+        die "$(getPrefix "$src"): No tasks moved."
     fi
     ;;
 

--- a/todo.sh
+++ b/todo.sh
@@ -1393,8 +1393,9 @@ case $action in
         echo "$todo" >> "$dest"
 
         if [ "$TODOTXT_VERBOSE" -gt 0 ]; then
+            destNum=$(sed -n '$ =' "$dest")
             echo "$item $todo"
-            echo "$(getPrefix "$src"): $item moved to $(getPrefix "$dest")."
+            echo "$(getPrefix "$src"): $item moved to $destNum in $(getPrefix "$dest")."
         fi
     else
         die "$(getPrefix "$src"): No tasks moved."


### PR DESCRIPTION
This avoids the lookup of the resulting task number when applying subsequent actions to the moved task (or when undoing an accidental move).

Prefixes (i.e. "TODO:") are used to indicate the active todo file; the full file name just clutters the output as both source and destination are in `$TODO_DIR`, anyway.

**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [X] If you've added code that should be tested, add tests!
- [X] Ensure the test suite passes.
- [X] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes.
- [X] Resolves #461