### PR TITLE
BUG: Documentation: Backslashes in help for list|ls need to be escaped

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -219,11 +219,11 @@ actionsHelp()
 		      Displays all tasks that contain TERM(s) sorted by priority with line
 		      numbers.  Each task must match all TERM(s) (logical AND); to display
 		      tasks that contain any TERM (logical OR), use
-		      'TERM1\|TERM2\|...' (with quotes), or TERM1\\\|TERM2 (unquoted).
+		      'TERM1\\|TERM2\\|...' (with quotes), or TERM1\\\\\\|TERM2 (unquoted).
 		      Hides all tasks that contain TERM(s) preceded by a
 		      minus sign (i.e. -TERM).
 		      TERM(s) are grep-style basic regular expressions; for literal matching,
-		      put a single backslash before any [ ] \ $ * . ^ and enclose the entire
+		      put a single backslash before any [ ] \\ \$ * . ^ and enclose the entire
 		      TERM in single quotes, or use double backslashes and extra shell-quoting.
 		      If no TERM specified, lists entire todo.txt.
 


### PR DESCRIPTION
As parameter extension is active in the here-document.
Escape the literal "$" as well; not needed, but better style.

Fixes #472

**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] ~~If you've added code that should be tested, add tests!~~
- [X] Ensure the test suite passes.
- [X] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes.
- [X] Have a `fixes #XX` reference to the issue that this pull request fixes.