### PR TITLE
Documentation: Use phrasing in move|mv actions help that is consistent with listfile|lf

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -288,10 +288,9 @@ actionsHelp()
 
 		    move NR DEST [SRC]
 		    mv NR DEST [SRC]
-		      Moves the line NR from source text file (SRC) to destination text file (DEST).
-		      Both source and destination file must be located in the directory defined
-		      in the configuration directory.  When SRC is not defined
-		      it's by default todo.txt.
+		      Moves the line NR from source file (SRC) to destination file (DEST).
+		      Both files must be located in the todo.txt directory. SRC defaults to
+		      todo.txt.
 
 		    prepend NR "TEXT TO PREPEND"
 		    prep NR "TEXT TO PREPEND"


### PR DESCRIPTION
- The last change made the first line longer than 80 characters, leading to ugly wrapping.
- Use "file" instead of "text file". It's an obvious characteristic of todo.txt that it's plain text.
- "in the configuration directory" is wrong; it's a config file. Use "todo.txt directory" instead, like listfile.
- The defaulting sentence is clumsy; reword.


**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] ~~If you've added code that should be tested, add tests!~~
- [X] Ensure the test suite passes.
- [ ] ~~Lint your code with [ShellCheck](https://www.shellcheck.net/).~~
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes.
- [ ] ~~Have a `fixes #XX` reference to the issue that this pull request fixes.~~