### PR TITLE
Consistency: FIX: Minor: Usage help should go to standard error, not standard output

### DIFF
--- a/todo.sh
+++ b/todo.sh
@@ -48,7 +48,7 @@ sed() {
 
 usage()
 {
-    cat <<-EndUsage
+    cat >&2 <<-EndUsage
 		Usage: $oneline_usage
 		Try '$TODO_SH -h' for more information.
 	EndUsage


### PR DESCRIPTION
As is customary, and also done by all other error messages / `dieWithHelp()`.
The benefit is that clients can suppress the errors if they're only interested in the output of a successful run, and that errors don't get accidentally captured and processed as if they were valid task data.
Unfortunately, `test_run_()` always captures the combined out and err streams, so this cannot be tested automatically.


**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] ~~If you've added code that should be tested, add tests!~~
- [X] Ensure the test suite passes.
- [X] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes: `$ todo.sh doesNotExist >/dev/null` still shows usage help
- [ ] ~~Have a `fixes #XX` reference to the issue that this pull request fixes.~~