### PR TITLE
TESTSFIX: Consistency: GEN-VERSION-FILE defaults to irregular v0.0 version

### DIFF
--- a/GEN-VERSION-FILE
+++ b/GEN-VERSION-FILE
@@ -2,7 +2,7 @@
 # Based on git's GIT-VERSION-GEN.
 
 VF=VERSION-FILE
-DEF_VER=v0.0
+DEF_VER=v0.0.0
 
 if test -d .git -o -f .git &&
 	VN=$(git describe --dirty --tags 2>/dev/null)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,11 +7,11 @@ Older versions may no longer be supported and may have known vulnerabilities.
 
 ## Reporting a Vulnerability
 
-If you find a security vulnerability, do **NOT** open an issue. Get ahold of the [maintainers](https://github.com/orgs/todotxt/teams/core) personally (i.e. email or private chat - you can use the [discussions](https://github.com/todotxt/todo.txt-cli/discussions/categories/general) to ask for preferred security contact information).
+If you find a security vulnerability, please **do NOT open a public issue**. Instead, use _Report a vulnerability_ (found under _Security and quality_) on this repository to submit your report or patch confidentially. This allows the maintainers to investigate the issue privately and work with you on a fix.
 
-In order to determine whether you are dealing with a security issue, ask yourself these two questions:
+If you're unsure whether something is a security vulnerability, ask yourself:
 
 - Can I access something that's not mine, or something I shouldn't have access to?
 - Can I disable something for other people?
 
-If the answer to either of those two questions is "yes", then you're probably dealing with a security issue. Note that even if you answer "no" to both questions, you may still be dealing with a security issue, so if you're unsure, just contact us directly.
+If the answer to either question is "yes", you're probably dealing with a security issue. Note that even if you answer "no" to both questions, you may still be dealing with a security issue, so if you're unsure, report it privately, too.

--- a/tests/t0200-version.sh
+++ b/tests/t0200-version.sh
@@ -8,7 +8,7 @@ on -V.
 '
 . ./test-lib.sh
 
-todoShFilespec="$(command -v todo.sh)"
+todoShFilespec=$(command -v todo.sh)
 isDevVersion() {
     grep --quiet --fixed-strings '@DEV_VERSION@' -- "$todoShFilespec"
 }
@@ -36,7 +36,7 @@ EOF
 rm -- "$versionFilespec"
 else
 test_expect_success 'distribution todo.sh -V displays an embedded version' '
-    todo.sh -V | head -n 1 | grep --line-regexp "^TODO.TXT Command Line Interface v[0-9]\\+\\.[0-9]\\+\\..*\$"
+    todo.sh -V | head -n 1 | grep --line-regexp "TODO.TXT Command Line Interface v[0-9]\\+\\.[0-9]\\+\\..*"
 '
 versionFilespec="$(dirname "$todoShFilespec")/VERSION-FILE"
 echo 'VERSION=A.B.C' > "$versionFilespec"


### PR DESCRIPTION
And that causes a test failure in the GitHub workflow (with its shallow checkout and no fetching of release tags), but not in a local working copy (with its full history), so it only was detected after the merge.

Also change SECURITY.md to instruct users to use GitHub's private vulnerability reporting instead of contacting the maintainers privately, which is messy and cumbersome.

**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] ~~If you've added code that should be tested, add tests!~~
- [X] Ensure the test suite passes.
- [X] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [ ] ~~Steps for the reviewer(s) on how they can manually QA the changes.~~
- [ ] ~~Have a `fixes #XX` reference to the issue that this pull request fixes.~~