### PR TITLE
Tests: BUG: TODO_DIR replacement broken by change to config file

### DIFF
--- a/tests/t0000-config.sh
+++ b/tests/t0000-config.sh
@@ -25,12 +25,12 @@ Usage: todo.sh [-fhpantvV] [-d todo_config] action [task_number] [task_descripti
 Try 'todo.sh -h' for more information.
 EOF
 
-cat > test.cfg <<EOF
+cat > test.cfg <<'EOF'
 export TODO_DIR=.
-export TODO_FILE="\$TODO_DIR/todo.txt"
-export DONE_FILE="\$TODO_DIR/done.txt"
-export REPORT_FILE="\$TODO_DIR/report.txt"
-export TMP_FILE="\$TODO_DIR/todo.tmp"
+export TODO_FILE="$TODO_DIR/todo.txt"
+export DONE_FILE="$TODO_DIR/done.txt"
+export REPORT_FILE="$TODO_DIR/report.txt"
+export TMP_FILE="$TODO_DIR/todo.tmp"
 touch used_config
 EOF
 

--- a/tests/t2200-no-done-report-files.sh
+++ b/tests/t2200-no-done-report-files.sh
@@ -7,12 +7,12 @@ checks that no such empty files are created.
 '
 . ./test-lib.sh
 
-cat > test.cfg <<EOF
+cat > test.cfg <<'EOF'
 export TODO_DIR=.
-export TODO_FILE="\$TODO_DIR/todo.txt"
+export TODO_FILE="$TODO_DIR/todo.txt"
 export DONE_FILE=/dev/null
 export REPORT_FILE=/dev/null
-export TMP_FILE="\$TODO_DIR/todo.tmp"
+export TMP_FILE="$TODO_DIR/todo.tmp"
 touch used_config
 EOF
 

--- a/tests/t6040-completion-files.sh
+++ b/tests/t6040-completion-files.sh
@@ -6,7 +6,7 @@ This test checks todo_completion of files in TODO_DIR.
 '
 . ./test-lib.sh
 
-> dummy.txt
+: > dummy.txt
 readonly FILES='done.txt dummy.txt report.txt todo.txt'
 test_todo_completion 'all files after addto' 'todo.sh addto ' "$FILES"
 test_todo_completion 'files beginning with d after addto' 'todo.sh addto d' 'done.txt dummy.txt'

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -41,7 +41,7 @@ unset CDPATH
 # Protect ourselves from using predefined TODOTXT_CFG_FILE
 unset TODOTXT_CFG_FILE $(set|sed '/^TODOTXT_/!d;s/=.*//')
 # To prevent any damage if someone has still those exported somehow in his env:
-unset TODO_FILE DONE_FILE REPORT_FILE TMP_FILE
+unset TODO_DIR TODO_FILE DONE_FILE REPORT_FILE TMP_FILE
 
 # Each test should start with something like this, after copyright notices:
 #
@@ -418,8 +418,8 @@ test_init_todo () {
 	root="$1"
 	mkdir -p "$root"
 	cd "$root" || error "Cannot setup todo dir in $root"
-	# Initialize the configuration file. Carefully quoted.
-	sed -e 's|: \${TODO_DIR:=.*$|TODO_DIR="'"$TEST_DIRECTORY/$test"'"|' "$SRC_DIRECTORY/todo.cfg" > todo.cfg
+	# Provide the configuration file.
+	cp -- "$SRC_DIRECTORY/todo.cfg" todo.cfg
 
 	# Install latest todo.sh
 	mkdir bin

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -419,7 +419,7 @@ test_init_todo () {
 	mkdir -p "$root"
 	cd "$root" || error "Cannot setup todo dir in $root"
 	# Initialize the configuration file. Carefully quoted.
-	sed -e 's|TODO_DIR=.*$|TODO_DIR="'"$TEST_DIRECTORY/$test"'"|' "$SRC_DIRECTORY/todo.cfg" > todo.cfg
+	sed -e 's|: \${TODO_DIR:=.*$|TODO_DIR="'"$TEST_DIRECTORY/$test"'"|' "$SRC_DIRECTORY/todo.cfg" > todo.cfg
 
 	# Install latest todo.sh
 	mkdir bin


### PR DESCRIPTION
As long as `TODO_DIR` isn't defined, the defaulting to `$HOME` (which is redirected inside tests) still made this work. But a predefined `TODO_DIR` broke it.

**Before submitting a pull request,** please make sure the following is done:

- [X] Fork [the repository](https://github.com/todotxt/todo.txt-cli) and create your branch from `master`.
- [ ] ~~If you've added code that should be tested, add tests!~~
- [X] Ensure the test suite passes.
- [X] Lint your code with [ShellCheck](https://www.shellcheck.net/).
- [X] Include a human-readable description of what the pull request is trying to accomplish.
- [X] Steps for the reviewer(s) on how they can manually QA the changes: Run `TODO_DIR=/path/to/nowhere make test` and it previously failed
- [X] Have a `fixes #XX` reference to the issue that this pull request fixes.